### PR TITLE
Content-ID should be a MIME header

### DIFF
--- a/pages/documentation/batch-processing-v2.html
+++ b/pages/documentation/batch-processing-v2.html
@@ -114,12 +114,12 @@ Content-Length: ###
 --changeset_77162fcd-b8da-41ac-a9f8-9357efbbd621 
 Content-Type: application/http 
 Content-Transfer-Encoding: binary 
+Content-ID: 1
 
 POST /service/Customers HTTP/1.1 
 Host: host  
 Content-Type: application/atom+xml;type=entry 
 Content-Length: ###
-Content-ID: 1
 
 &lt;AtomPub representation of a new Customer&gt; 
 

--- a/pages/documentation/batch-processing-v3.html
+++ b/pages/documentation/batch-processing-v3.html
@@ -119,12 +119,12 @@ Content-Length: ###
 --changeset_77162fcd-b8da-41ac-a9f8-9357efbbd621
 Content-Type: application/http 
 Content-Transfer-Encoding: binary 
+Content-ID: 1 
 
 POST /service/Customers HTTP/1.1 
 Host: host  
 Content-Type: application/atom+xml;type=entry 
 Content-Length: ### 
-Content-ID: 1 
 
 &lt;AtomPub representation of a new Customer&gt; 
 


### PR DESCRIPTION
We found a problem in the Content-ID sample on the odata.org (http://www.odata.org/documentation/odata-version-2-0/batch-processing/  ---- 2.2.1. Referencing Requests in a Change Set). The sample shows the Content-ID as an Operation header, but the specification (http://download.microsoft.com/download/9/5/E/95EF66AF-9026-4BB0-A41D-A4F81802D92C/[MS-ODATA].pdf ) says that it should be a MIME header:
“Each MIME part that represents a request in a change set MUST include a Content-ID MIME header as an HTTP header of the MIME part request.”
This is an interesting situation as:
·         The SAP Gateway supports both places
·         The MS OData service supports only as Operation header
·         The SQLA/ASE/IQ OData services are supporting only as MIME header

So, I'm modifying the sample according to the specification.