### PR TITLE
Fixed batch sample according to [MS-ODATA] 2.2.7.6.5

### DIFF
--- a/pages/documentation/batch-processing-v2.html
+++ b/pages/documentation/batch-processing-v2.html
@@ -54,6 +54,7 @@ Content-Transfer-Encoding:binary
 GET /service/Customers('ALFKI') HTTP/1.1
 Host: host
 
+
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b 
 Content-Type: multipart/mixed; boundary=changeset_77162fcd-b8da-41ac-a9f8-9357efbbd621 
 Content-Length: ###       
@@ -89,6 +90,7 @@ Content-Transfer-Encoding:binary
 
 GET service/Products HTTP/1.1 
 Host: host 
+
 
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b--</pre>
 <h4><a id="ReferencingRequestsInAChangeSet" name="ReferencingRequestsInAChangeSet"></a> 2.2.1. Referencing Requests in a Change Set</h4>


### PR DESCRIPTION
According to MS-OData documentation in section [2.2.7.6.5 Example Batch Request](https://msdn.microsoft.com/en-us/library/dd541538.aspx) there must be an additional empty line after the GET request line.