### PR TITLE
Add Odata2Poco in Libraries

### DIFF
--- a/_libraries/OData2Poco.md
+++ b/_libraries/OData2Poco.md
@@ -1,0 +1,15 @@
+---
+category: net
+name: OData2Poco
+rownumber: 35
+link: https://github.com/moh-hassan/odata2poco
+version: V1-V4
+object: Client
+downloads:
+  - source: nugetgallery
+    link: https://www.nuget.org/packages/OData2Poco.CommandLine/
+  - source: nugetgallery
+    link: https://www.nuget.org/packages/OData2Poco/
+---
+A code generation tool for generating plain-old CLR objects (POCO) from OData feeds. Code generation can be controlled by setting many options.
+OData2Poco is available in two flavours: OData2Poco.CommandLine (a.k.a o2pgen) and OData2Poco class library. 


### PR DESCRIPTION
Add the code generation client tool OData2Poco to Libraries.  OData2Poco  is hosted in [GitHub](https://github.com/moh-hassan/odata2poco) under MIT License.
OData2Poco is a code generation tool for generating plain-old CLR objects (POCO) from OData feeds. Code generation can be controlled by setting many options.
OData2Poco is available in two flavours:  [OData2Poco.CommandLine (a.k.a o2pgen) ](https://www.nuget.org/packages/OData2Poco.CommandLine/) and  [OData2Poco class library](https://www.nuget.org/packages/OData2Poco/) 