### PR TITLE
Corrected year

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 ﻿<footer class="content-info" role="contentinfo">
 
 <div class="container" style=" text-align: center">
-  <p>&copy; 2015-2017 OData – The Protocol for REST APIs </p>
+  <p>&copy; 2015-2018 OData – The Protocol for REST APIs </p>
 </div>
 
 </footer>


### PR DESCRIPTION
Footer was still displaying 2017. Corrected to show 2018.