### PR TITLE
Add ODataHttpClient in Libraries 

### DIFF
--- a/_libraries/ODataHttpClient.md
+++ b/_libraries/ODataHttpClient.md
@@ -1,0 +1,11 @@
+---
+category: net
+name: ODataHttpClient
+link: https://iwate.github.io/ODataHttpClient/
+version: V3-V4
+object: Client
+downloads:
+  - source: nugetgallery
+    link: https://www.nuget.org/packages/ODataHttpClient
+---
+A thin OData client library for JSON payload.


### PR DESCRIPTION
This PR adds new client library for .NET Standard.

Lib Name: ODataHttpClient
Link: https://iwate.github.io/ODataHttpClient/
Repository: https://github.com/iwate/ODataHttpClient
LICENSE: MIT
