### PR TITLE
Accessibility issue: <html> element must have a lang attribute.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
   {% include head.html %}
 


### PR DESCRIPTION
Issue: <html> element must have a lang attribute (html)

Add a lang attribute to the html element (e.g. <html lang="en">) whose value represents the primary language of document.

Detail:

OData - the Best Way to REST has an accessibility issue that needs investigation.

Issue Details
<html> element must have a lang attribute
html-has-lang

Application
OData - the Best Way to REST
https://www.odata.org/

Note: Similar issue is found in all the pages in entire application

Element Path
html

Snippet
<html>

How to fix
Fix any of the following:
- The <html> element does not have a lang attribute

To reproduce
Use K4W to investigate the issue details

Environment
Chrome version 70.0.3538.77

This accessibility issue was found using Keros for Web, a tool that helps debug and find accessibility issues earlier. Get more information & download this tool at http://aka.ms/K4Web.