### PR TITLE
OData in 6 steps tab-pane references

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -586,10 +586,10 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <li><a href="#csharpSimpleOData2" tabindex="-1" role="tab" id="csharpSimpleOData2-tab" data-toggle="tab" aira-controls="csharpSimpleOData2">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-1" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-1" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-1" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-1" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-2" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-2" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-2" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-2" aria-controls="contribute-2" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http2">
@@ -694,10 +694,10 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <li><a href="#csharpSimpleOData3" tabindex="-1" role="tab" id="csharpSimpleOData3-tab" data-toggle="tab" aira-controls="csharpSimpleOData3">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-1" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-1" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-1" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-1" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-3" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-3" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-3" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-3" aria-controls="contribute-3" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http3">


### PR DESCRIPTION
At "Understand OData in 6 Steps" page, the references in the tabpanes of section 2 and 3 were pointing at the section 1, so the user was not able to change the example languages. At this pull request I correted this wrong behavior.

To reproduce the error just open the bellow webpage and try to click at any tabpane of section 2 or 3.

[Understand OData in 6 steps](https://www.odata.org/getting-started/understand-odata-in-6-steps/)

