### PR TITLE
Fix typo in 1C producer description

### DIFF
--- a/_ecosys/producers/1C-Enterprise-built-in-odata-service.md
+++ b/_ecosys/producers/1C-Enterprise-built-in-odata-service.md
@@ -4,4 +4,4 @@ category: producers
 title: "1C: Enterprise built-in OData service"
 link: "http://1c-dn.com/1c_enterprise/"
 ---
-1C:Enterprise, leading platform for business automnation in Russia and CIS (more than 1M installations and 300k developers) now provides an OData service for access its data.
+1C:Enterprise, leading platform for business automation in Russia and CIS (more than 1M installations and 300k developers) now provides an OData service for access its data.


### PR DESCRIPTION
Description for 1C:Enterprise producer contains a typo: "automnation" instead of "automation"