### PR TITLE
Fix missing ARIA label in div

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ layout: default
     </ol>
 
     <!-- Wrapper for slides -->
-    <div class="carousel-inner zero-side-margin" role="listbox">
+    <div class="carousel-inner zero-side-margin" aria-label="OData Description" role="listbox">
       <div class="item active">
         <img src="{{ '/assets/homepage_1.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Home">
         <div class="carousel-caption jumbotron transparent-background">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ layout: default
 
     <!-- Wrapper for slides -->
     <div class="carousel-inner zero-side-margin" aria-label="OData Description" role="listbox">
-      <div class="item active">
+      <div class="item active" role="option">
         <img src="{{ '/assets/homepage_1.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Home">
         <div class="carousel-caption jumbotron transparent-background">
             <h1 class="text-center">OData - the best way to REST</h1>


### PR DESCRIPTION
Fixes the following accessibility issues highlighted by Accessibility Insights

Element path: .carousel-inner​
​
Snippet: <div class="carousel-inner zero-side-margin" role="listbox">​
​
How to fix: ​
Fix any of the following:​
  aria-label attribute does not exist or is empty​
  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty​
  Element has no title attribute or the title attribute is empty​
​

Element path: .carousel-inner​
​
Snippet: <div class="carousel-inner zero-side-margin" role="listbox">​
​
How to fix: ​
Fix any of the following:​
  Required ARIA child role not present: option​