### PR TITLE
917860: Accessibility fix for tab items narrations

### DIFF
--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -6,13 +6,13 @@ permalink: /odata-services/
 ---
 <div role="tablist" aria-label="Versions">
 <ul class="nav nav-pills">
-  <li class="active">
+  <li role="presentation" class="active">
     <a role="tab" href="#odata-v4" aria-controls="odata-v4" data-toggle="pill">OData v4</a>
   </li>
-  <li>
+  <li role="presentation">
     <a role="tab" href="#v3" data-toggle="pill" aria-controls="v3" tabindex="-1">OData v3</a>
   </li>
-  <li>
+  <li role="presentation">
     <a role="tab" href="#v2" data-toggle="pill" aria-controls="v2" tabindex="-1">OData v2</a>
   </li>
 </ul>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description
This PR fixes this [issue](https://github.com/OData/odataorg.github.io/issues/211) where the screen reader narration for tab items is misleading. The three tabs OData v4, OData v3 and OData v2 are incorrectly narrated as 

_OData  v4 tab item 1 of 1_,
_OData  v3 tab item 1 of 1_ and 
_OData  v2 tab item 1 of 1_

respectively, instead of 

_OData  v4 tab item 1 of 3_,
_OData  v3 tab item 2 of 3_ and 
_OData  v2 tab item 3 of 3_

Link to page: https://www.odata.org/odata-services/