### PR TITLE
Update page.html

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="container">
   <div class="page-header">
-    <h1 role="heading" aria-level="1" >{{ page.title }}</h1>
+    <h1>{{ page.title }}</h1>
   </div>
   {{ content }}
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="container">
   <div class="page-header">
-    <h1 role="heading">{{ page.title }}</h1>
+    <h1 role="heading" aria-level="1" >{{ page.title }}</h1>
   </div>
   {{ content }}
 </div>


### PR DESCRIPTION
Environment Details: 
#URL:https://www.odata.org/ 

Note: The same issue is observed in all the pages in core scenarios except the OData home, OData 4.01 Committee Spec Approved,OData API Explorer,Response popup.

Issue: Ensures elements with ARIA roles have all required ARIA attributes (aria-required-attr - https://dequeuniversity.com/rules/axe/3.3/aria-required-attr?application=msftAI)
​
Target application: Blog · OData - the Best Way to REST - https://www.odata.org/blog/ 
​
Element path: h1 
​
Snippet: <h1 role="heading">Blog</h1> 
​
How to fix: 
Fix any of the following: 
  Required ARIA attribute not present: aria-level 
​
Environment: Chrome version 79.0.3945.130 
​
==== 
​
This accessibility issue was found using Accessibility Insights for Web 2.14.1 (axe-core 3.3.2), a tool that helps find and fix accessibility issues. Get more information & download this tool at http://aka.ms/AccessibilityInsights.

MAS Reference:
https://microsoft.sharepoint.com/:w:/r/teams/msenable/_layouts/15/WopiFrame.aspx?sourcedoc={2e2a1540-aaf7-48a0-a53e-8f10cf309999}

https://microsoft.sharepoint.com/:w:/r/teams/msenable/_layouts/15/WopiFrame.aspx?sourcedoc={248054a6-5e68-4771-9e1e-242fb5025730}
