### PR TITLE
Focus on modal button when a modal opens

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1352,3 +1352,25 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 </p></div>
 </p></div>
 </p></div>
+<script>
+    $(document).ready(function() {
+       $('#step-collection-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+       $('#step-individual-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+       $('#step-query-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+       $('#step-post-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+       $('#step-relationship-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+       $('#step-function-modal').on('shown.bs.modal', function () {
+            $('.btn-default').focus();
+       });
+    })
+</script>

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1354,7 +1354,7 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 </p></div>
 <script>
     $(document).ready(function() {
-       $('#step-collection-modal,#step-individual-modal,#step-query-modal,#step-post-modal,#step-relationship-modal,#step-function-modal').on('shown.bs.modal', function () {
+       $('.modal').on('shown.bs.modal', function () {
             $('.btn-default').focus();
        });
     })

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1354,22 +1354,7 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 </p></div>
 <script>
     $(document).ready(function() {
-       $('#step-collection-modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
-       });
-       $('#step-individual-modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
-       });
-       $('#step-query-modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
-       });
-       $('#step-post-modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
-       });
-       $('#step-relationship-modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
-       });
-       $('#step-function-modal').on('shown.bs.modal', function () {
+       $('#step-collection-modal,#step-individual-modal,#step-query-modal,#step-post-modal,#step-relationship-modal,#step-function-modal').on('shown.bs.modal', function () {
             $('.btn-default').focus();
        });
     })


### PR DESCRIPTION
Focus gets lost on all controls in a modal window when a modal window opens on this page https://www.odata.org/getting-started/understand-odata-in-6-steps/. 
 This PR fixes this issue. That is focus is maintained on a close-modal button control when a modal window opens. 

Repro Steps: ​​​
1)Hit the URL "https://www.odata.org/" to open Odata website​
2)Tab till 'Developers' link and press enter​
3)Tab till 'Getting Started' option and press enter​
4)Tab till 'Understand OData in 6 steps' link and press enter​
5)Tab till 'View the response' button and press enter​
6)Verify Focus is visible on any control or not after the 'Close' button in 'Response' popup​
​
​Actual Result: ​​​
Focus is not visible on any control(focus is lost) after the 'Close' button and one extra keyboard stroke is taking to reach to the close button symbol present in the top of the popup
​
Expected Result:​
Focus should be visible on next control (close button symbol )with in the popup, focus shouldn't be lost after the 'Close' button​.