### PR TITLE
Fix image zooming accessibility issue

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 ﻿<footer class="content-info" role="contentinfo">
 
 <div class="container" style=" text-align: center">
-  <p>&copy; 2015-2018 OData – The Protocol for REST APIs </p>
+  <p>&copy; 2015-{{ 'now' | date: "%Y" }} OData – The Protocol for REST APIs </p>
 </div>
 
 </footer>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ layout: default
     </ol>
 
     <!-- Wrapper for slides -->
-    <div class="carousel-inner zero-side-margin" role="listbox">
+    <div class="carousel-inner zero-side-margin" aria-label="OData Description" role="listbox">
       <div class="item active">
         <img src="{{ '/assets/homepage_1.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Home">
         <div class="carousel-caption jumbotron transparent-background">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ layout: default
 
     <!-- Wrapper for slides -->
     <div class="carousel-inner zero-side-margin" aria-label="OData Description" role="listbox">
-      <div class="item active">
+      <div class="item active" role="option">
         <img src="{{ '/assets/homepage_1.jpg' | prepend: site.baseurl | prepend: site.url }}" alt="Home">
         <div class="carousel-caption jumbotron transparent-background">
             <h1 class="text-center">OData - the best way to REST</h1>

--- a/pages/contribution.html
+++ b/pages/contribution.html
@@ -6,7 +6,7 @@ permalink: /contribution/
 
 
 <h2 class="text-center" >Contribute to OData.org</h2>
-<div class="row" style="height:210px ; text-align:center">
+<div class="row" style="height:auto; text-align:center">
 
 <div>
 		<p class="text-center">OData.org is always open to any kind of contribution, including <strong>Post blogs</strong>, adding contents to <strong>Ecosystem</strong>, <strong>Libraries</strong> and <strong>other improvements </strong>. Please visit OData.org repo on GitHub for more details. Or if you have any further questions / feedback, please create <a href="https://github.com/ODataOrg/odataorg.github.io/issues">GitHub issues</a> or send email to <a href="mailto:odata-discussion@googlegroups.com">odata-discussion@googlegroups.com</a>.</p>
@@ -15,7 +15,7 @@ permalink: /contribution/
 
 
 <h2 class="text-center">Participate elsewhere</h2>
-<div class="row" style="height:210px;text-align:center">
+<div class="row" style="height:auto;text-align:center">
 
 	<div>
 		<p class="text-center">You can also view issues and discuss OData in other communities. You can participate or follow the standardization technical committee progress at OASIS, ask questions at StackOverflow and tweet #OData at Twitter.</p>
@@ -29,7 +29,7 @@ permalink: /contribution/
 </div>
 
 <h2 class="text-center">Join discussion groups</h2>
-<div class="row" style="height:210px; text-align:center">
+<div class="row" style="height:auto; text-align:center">
 	<div>
 		<p class="text-center">Join the new mailing list for OData discussion. You can ask or answer questions about the OData protocol.</p>
 	</div>
@@ -42,7 +42,7 @@ permalink: /contribution/
 </div>			
 
 <h2 class="text-center">Contact us</h2>
-<div class="row" style="height:210px; text-align:center">
+<div class="row" style="height:auto; text-align:center">
 	<div>
 		<p class="text-center">Contact us directly about any suggestion or advice for OData.org.</p>
 	</div>

--- a/pages/contribution.html
+++ b/pages/contribution.html
@@ -15,7 +15,7 @@ permalink: /contribution/
 
 
 <h2 class="text-center">Participate elsewhere</h2>
-<div class="row" style="height:auto;text-align:center">
+<div class="row text-center">
 
 	<div>
 		<p class="text-center">You can also view issues and discuss OData in other communities. You can participate or follow the standardization technical committee progress at OASIS, ask questions at StackOverflow and tweet #OData at Twitter.</p>
@@ -29,7 +29,7 @@ permalink: /contribution/
 </div>
 
 <h2 class="text-center">Join discussion groups</h2>
-<div class="row" style="height:auto; text-align:center">
+<div class="row text-center">
 	<div>
 		<p class="text-center">Join the new mailing list for OData discussion. You can ask or answer questions about the OData protocol.</p>
 	</div>
@@ -42,7 +42,7 @@ permalink: /contribution/
 </div>			
 
 <h2 class="text-center">Contact us</h2>
-<div class="row" style="height:auto; text-align:center">
+<div class="row text-center">
 	<div>
 		<p class="text-center">Contact us directly about any suggestion or advice for OData.org.</p>
 	</div>


### PR DESCRIPTION
Issue: When the page is reflowed(Zoom to 400%), then content and images are overlapping in the community section​