### PR TITLE
Fix table zooming by removing table-responsive css class

### DIFF
--- a/pages/ecosystem.html
+++ b/pages/ecosystem.html
@@ -21,7 +21,7 @@ permalink: /ecosystem/
 	OData producers are services that expose their data using the OData protocol. Below we have collected a list of key OData producers, which will continue to grow along with the OData ecosystem. You can use <a href="https://www.odata.org/libraries">OData SDK</a> to build your own OData producers. If you create or know of an OData producer not listed be sure to let us know via our new <a href="https://www.odata.org/contribution">contribution page</a>.
 
 	<a href="http://www.telerik.com/products/orm.aspx">Telerik OpenAccess ORM</a>In mid-2010 Telerik released a LINQ implementation that is simple to use and produces domain models very fast. Built on top of the enterprise-grade Telerik OpenAccess ORM the LINQ implementation allows you to easily build an OData feed via a few easy steps by using the OpenAccess Visual Designer and the Data Services Wizard. For more info, visit <a href="https://www.telerik.com/odata">www.telerik.com/odata</a>
-	<table class="table table-striped table-hover table-responsiv">
+	<table class="table table-striped table-hover">
 	<tbody>
 		{% assign producers = site.ecosys | where: "category", "producers" %}
 		{% for producer in producers %}

--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -25,7 +25,7 @@ permalink: /libraries/
 </div>
 <p></p>
 <div class="tab-content">
-  <div class="tab-pane active table-responsive" id="net1">
+  <div class="tab-pane active " id="net1">
     <table class="table table-striped table-condensed table-hover" style="width:100%">
       <tr>
         <th width="20%">Name</th>
@@ -57,7 +57,7 @@ permalink: /libraries/
   </div>
   {% assign libraries = site.libraries | group_by: "category" %}
   {% for library in libraries %}
-  <div class="tab-pane table-responsive" id={{library.name}}>
+  <div class="tab-pane " id={{library.name}}>
     <table class="table table-striped table-condensed table-hover" style="width:100%">
       <tr>
         <th width="20%">Name</th>


### PR DESCRIPTION
Fixes issue: When the page is reflowed(Zoom to 400%), then two scroll bars is coming in 'Getting Started' section​