### PR TITLE
Allow response code in popup modals to be tabbed and scrolled via keyboard

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -76,7 +76,7 @@ permalink: /getting-started/understand-odata-in-6-steps/
 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></p>
 <h4 class="modal-title" id="step-collection-modal-label">Response</h4>
 </p></div>
-<div class="modal-body">
+<div class="modal-body sr-focusable">
 {% highlight js %}
 HTTP/1.1 200 OK
 Content-Length: 1007
@@ -1356,9 +1356,12 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
     $(document).ready(function() {
        $('.modal').on('shown.bs.modal', function () {
             $('.btn-default').focus();
+            $(this).find(".modal-body").attr("tabindex", 0);
        });
-    })
 
-    // make it possible to tab to response content inside popups
-    $(".modal-body").attr("tabindex", 0);
+       // make it possible to tab to response content inside popups
+       // and make accessible to screen readers
+        $(".modal-body pre").attr("tabindex", 0);
+        $(".modal-body").attr("aria-label", "Response body");
+    });
 </script>

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -64,7 +64,7 @@ permalink: /getting-started/understand-odata-in-6-steps/
     max-height: 100px;
 }
 #top-link-block.affix-top{
-    position: absolute; 
+    position: absolute;
 }
 </style>
 
@@ -1359,9 +1359,25 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             $(this).find(".modal-body").attr("tabindex", 0);
        });
 
-       // make it possible to tab to response content inside popups
-       // and make accessible to screen readers
+        // make it possible to tab to response content inside popups for keyboard users
         $(".modal-body pre").attr("tabindex", 0);
         $(".modal-body").attr("aria-label", "Response body");
+        
+        // hack to get the screen reader to read the syntax-highlighted
+        // code section on Microsoft Edge
+        document.querySelectorAll(".modal-body").forEach((modalBody) => {
+            // extract plain code text form syntax-highlighted code section
+            let plainCode = "";
+            modalBody.querySelectorAll("pre span").forEach((span) => {
+                plainCode += `${span.textContent} `;
+            });
+            
+            // inject paragraph with plain code for screen readers
+            const screenReaderContent = document.createElement("p");
+            screenReaderContent.classList.add("sr-only");
+            screenReaderContent.tabIndex = 0;
+            screenReaderContent.textContent = plainCode;
+            modalBody.insertBefore(screenReaderContent, modalBody.firstChild);
+        });
     });
 </script>

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1365,15 +1365,15 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
         
         // hack to get the screen reader to read the syntax-highlighted
         // code section on Microsoft Edge
-        document.querySelectorAll(".modal-body").forEach((modalBody) => {
+        $('.modal-body').each(function (i, modalBody) {
             // extract plain code text form syntax-highlighted code section
-            let plainCode = "";
-            modalBody.querySelectorAll("pre span").forEach((span) => {
-                plainCode += `${span.textContent} `;
+            var plainCode = "";
+            $(modalBody).find("pre span").each(function (spanIndex, span) {
+                plainCode += span.textContent + ' ';
             });
             
             // inject paragraph with plain code for screen readers
-            const screenReaderContent = document.createElement("p");
+            var screenReaderContent = document.createElement("p");
             screenReaderContent.classList.add("sr-only");
             screenReaderContent.tabIndex = 0;
             screenReaderContent.textContent = plainCode;

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1358,4 +1358,7 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             $('.btn-default').focus();
        });
     })
+
+    // make it possible to tab to response content inside popups
+    $(".modal-body").attr("tabindex", 0);
 </script>


### PR DESCRIPTION
## Original Issue:

### Repro steps:
1)Hit the URL "https://www.odata.org/"  to open Odata website​
2)Tab till 'Developers' link and press enter​
3)Tab till 'Getting Started' option and press enter​
4)Tab till 'Understand OData in 6 steps' link and press enter​
5)Tab till 'View the response' button and press enter​
6)Verify we are able to view the content present in the response popup using keyboard arrow keys or not​
​
### Actual Result: ​​​
Unable to view the content present in the response popup using keyboard​
​
### Expected Result:​
Users should be able to view the content present in the response popup using keyboard​
​
### ​User Impact: ​​
Keyboard users will face problems if they are unable to view any content​ using keyboard


Actually, using the keyboard and following the repro steps, you would be able to view the response content. However, if the content does not fit the dialog, you can tab to it or scroll it.

I've added a `tabindex=0` to the `.modal-body` that contains the response content in each dialog on the page so that you can tab to it using the keyboard, then you can scroll down/up using arrow keys to view the entire response content.

The reason I set the `tabindex` using JS instead of just adding the attribute directly via html is because when I used html, it messed up the css of the modal, removing the margins or padding of the modal body for some reason.