### PR TITLE
Enable narrator to read list items positions correctly

### DIFF
--- a/pages/documentation/batch-processing-v3.html
+++ b/pages/documentation/batch-processing-v3.html
@@ -39,12 +39,11 @@ Content-Type: multipart/mixed; boundary=batch_36522ad7-fc75-4b56-8c71-56071383e7
 <p>The example below shows a sample batch request that contains the following operations in the order listed:</p>
 <ul>
 <li>Query request</li>
-<li>A Change Set that contains the following requests:
+<li>A Change Set that contains the following requests:</li>
 <ul>
 <li>Insert entity</li>
 <li>Update request</li>
 </ul>
-</li>
 <li>Second query request</li>
 </ul>
 <pre><code>POST /service/$batch HTTP/1.1 
@@ -101,12 +100,11 @@ Host: host
 <p>If a MIME part representing an Insert request within a ChangeSet includes a Content-ID header, then the new entity represented by that part may be referenced by subsequent requests within the same ChangeSet by referring to the Content-ID value prefixed with a “$” character. When used in this way, $&lt;contentIdValue&gt; acts as an alias for the URI that identifies the new entity.</p>
 <p>The example below shows a sample batch request that contains the following operations in the order listed:</p>
 <ul>
-<li>A ChangeSet that contains the following requests:
+<li>A ChangeSet that contains the following requests:</li>
 <ul>
 <li>Insert a new entity (with Content-ID = 1)</li>
 <li>Insert a second new entity (references request with Content-ID = 1)</li>
 </ul>
-</li>
 </ul>
 <pre><code>POST /service/$batch HTTP/1.1 
 Host: host 


### PR DESCRIPTION
Whenever we had nested list items, narrator was not reading the item position of the parent list item.
Browser Affected: MS Edge