### PR TITLE
Remove link to OData API Explorer under OData.org Tools menu

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -33,8 +33,6 @@
           <a class="dropdown-toggle" role="menuitem" data-toggle="dropdown" aria-label="Tools dropdown" data-target="#" href="#">Tools <b class="caret"></b></a>
           <ul class="dropdown-menu" role="menu">
             <li role="menuitem"><a role="menuitem" href="https://marketplace.visualstudio.com/items?itemName=stansw.vscode-odata " target="_blank">OData for Visual Studio Code</a></li>
-<!--            <li><a href="https://services.odata.org/validation/" target="_blank">OData Validator</a></li> -->
-            <li role="menuitem"><a role="menuitem" href="https://services.odata.org/ODataAPIExplorer/ODataAPIExplorer.html" target="_blank">OData API Explorer</a></li>
             <li role="menuitem"><a role="menuitem" href="https://pragmatiqa.com/xodata/" target="_blank">XOData</a></li>
           </ul>
         </li>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description
This PR fixes this [issue](https://github.com/OData/odataorg.github.io/issues/218) by removing the link to OData API Explorer under Tools menu since the explorer is not being actively maintained

Also to note that removal of the link has previously been suggested in [this](https://github.com/OData/odataorg.github.io/issues/32) issue

Navigation to the page https://www.odata.org > Tools > OData API Explorer
Page location: https://services.odata.org/ODataAPIExplorer/ODataAPIExplorer.html