### PR TITLE
updated the contrast between foreground and background colors on cm:n…

### DIFF
--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -4,7 +4,7 @@
 .err { color: #AA0000; background-color: #ffeded } /* Error */
 .k { color: #006699; } /* Keyword */
 .o { color: #555555 } /* Operator */
-.cm { color: #0099FF; font-style: italic } /* Comment.Multiline */
+.cm { color: #000cff; font-style: italic } /* Comment.Multiline */
 .cp { color: #005151 } /* Comment.Preproc */
 .c1 { color: #6b6b6b; } /* Comment.Single */
 .cs { color: #999; } /* Comment.Special */


### PR DESCRIPTION
Issue: Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds (color-contrast - https://dequeuniversity.com/rules/axe/3.3/color-contrast?application=msftAI)
​
Target application: JSON Format (OData Version 2.0) · OData - the Best Way to REST - https://www.odata.org/documentation/odata-version-2-0/json-format/​
​
Element path: .cm:nth-child(47)​
​
Snippet: <span class="cm">/* another Category Entry */</span>​
​
How to fix: ​
Fix any of the following:​
  Element has insufficient color contrast of 2.75 (foreground color: #0099ff, background color: #f5f5f5, font size: 9.8pt (13px), font weight: normal). Expected contrast ratio of 4.5:1​
<pre>//Before</pre>
<img width="220" alt="sn" src="https://user-images.githubusercontent.com/25525526/80952638-a3f45900-8e02-11ea-8852-41ed50e9a27e.PNG">
<pre>//After</pre>
<img width="230" alt="sn1" src="https://user-images.githubusercontent.com/25525526/80952675-b5d5fc00-8e02-11ea-920e-3c688b6172ac.PNG">

