### PR TITLE
Announce menuitem role in navbar in NVDA screen reader

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -17,8 +17,8 @@
 
     <div class="collapse navbar-collapse" id="odata-navbar-collapse">
 
-      <ul class="nav navbar-nav" role="menubar">
-        <li role="menuitem"><a role="menuitem" href="/blog">Blog</a></li>
+      <ul class="nav navbar-nav" role="navigation">
+        <li><a aria-label="Blog menuitem" href="/blog">Blog</a></li>
         <li class="dropdown" role="menuitem">
           <a class="dropdown-toggle" role="menuitem" data-toggle="dropdown" aria-label="Developers dropdown" data-target="#" href="#">Developers <b class="caret"></b></a>
           <ul class="dropdown-menu" role="menu">
@@ -36,8 +36,8 @@
             <li role="menuitem"><a role="menuitem" href="https://pragmatiqa.com/xodata/" target="_blank">XOData</a></li>
           </ul>
         </li>
-        <li role="menuitem"><a role="menuitem" href="/ecosystem">Ecosystem</a></li>
-        <li role="menuitem"><a role="menuitem" href="/contribution">Getting Involved</a></li>
+        <li><a aria-label="Ecosystem menuitem" href="/ecosystem">Ecosystem</a></li>
+        <li><a aria-label="Getting Involved menuitem" href="/contribution">Getting Involved</a></li>
       </ul>
       <form class="navbar-form navbar-left" role="search">
         <div class="form-group">


### PR DESCRIPTION
## Issue
### Repro Steps: ​​​
1.Start NVDA​
2.Hit the URL "https://www.odata.org/" to open Odata website​
3.Tab till 'Blog', 'Ecosystem', 'Getting Involved' controls​
4.Verify NVDA is announcing the role for 'Blog','Ecosystem','Getting Involved' controls or not​
​
### Actual Result: ​​​
NVDA is not announcing the role for 'Blog', 'Ecosystem', 'Getting Involved' controls​
​
### Expected Result:​
NVDA should read the role for 'Blog', 'Ecosystem', 'Getting Involved' controls​

## Proposed fix
According to [this issue](https://github.com/nvaccess/nvda/issues/8654) the fact NVDA does not announce "menu item" whenever it reads a control with a menu item role is not a bug, it's intentional.

However, I did find that if I kept the `role="menuitem"` in the `<li>` elements only and not in the enclosed `<a>` elements, then it did announce "menu item" after reading the text of the menu link. But surprisingly in this case, the "menu item" part does not get announced in Windows Narrator.

The workaround that worked for both Narrator and NVDA was to simply use `aria-label` attributes for the `<a>` elements in the list items, giving them labels like "Blog menuitem". Both NVDA and Narrator read the aria-label. But Narrator reads both the aria-label and the role, leading to the screen reader announcing "Blog menu item menu item". To avoid that issue, I removed the `role` attribute from the list items and their links. Instead, I replaced the `role=menubar` of the enclosing `ul` element with `role=navigation`.