### PR TITLE
Fix libraries page to prevent narrator from reading tab as selected when it is not

### DIFF
--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -5,27 +5,28 @@ date: 2014-02-20 06:57:09.000000000 +08:00
 permalink: /libraries/
 ---
 <div role="tablist" aria-label="Languages">
-<ul class="nav nav-pills">
-  <li class="active">
-    <a href="#net" role="tab" aria-label=".net"  data-toggle="pill">.NET</a>
+<ul class="nav nav-pills" id="tablinks">
+  <li role="presentation" class="active">
+    <a href="#net1" role="tab" aria-label=".net" data-toggle="pill" aria-controls="net1">.NET</a>
   </li>
-  <li>
-    <a href="#java" role="tab" aria-label="Java"data-toggle="pill">Java</a>
+  <li role="presentation">
+    <a href="#java" role="tab" aria-label="Java" data-toggle="pill" aria-controls="java" tabindex="-1">Java</a>
   </li>
-  <li>
-    <a href="#javascript" role="tab" aria-label="JavaScript" data-toggle="pill">JavaScript</a>
+  <li role="presentation">
+    <a href="#javascript" role="tab" aria-label="JavaScript" data-toggle="pill" aria-controls="javascript" tabindex="-1">JavaScript</a>
   </li>
-  <li>
-    <a href="#cpp" role="tab"  aria-label="C++" data-toggle="pill">C++</a>
+  <li role="presentation">
+    <a href="#cpp" role="tab"  aria-label="C++" data-toggle="pill" aria-controls="cpp" tabindex="-1">C++</a>
   </li>
-  <li>
-    <a href="#other" role="tab" aria-label="Other Platforms" data-toggle="pill">Other Platforms</a>
+  <li role="presentation">
+    <a href="#other" role="tab" aria-label="Other Platforms" data-toggle="pill" aria-controls="other" tabindex="-1">Other Platforms</a>
   </li>
 </ul>
 </div>
+
 <p></p>
 <div class="tab-content">
-  <div class="tab-pane active " id="net1">
+  <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
     <table class="table table-striped table-condensed table-hover" style="width:100%">
       <tr>
         <th width="20%">Name</th>
@@ -55,9 +56,11 @@ permalink: /libraries/
       {% endfor %}
     </table>
   </div>
+  
   {% assign libraries = site.libraries | group_by: "category" %}
   {% for library in libraries %}
-  <div class="tab-pane " id={{library.name}}>
+
+  <div class="tab-pane {% if forloop.first == true %}hide{% endif%}" id="{{library.name}}" role="tabpanel" hidden>
     <table class="table table-striped table-condensed table-hover" style="width:100%">
       <tr>
         <th width="20%">Name</th>

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -160,10 +160,10 @@
     var controls = tab.getAttribute('aria-controls');
 
     // Remove hidden attribute from tab panel to make it visible
-	if(document.getElementById(controls))
-	{
-		document.getElementById(controls).removeAttribute('hidden');
-	}
+    if(document.getElementById(controls))
+    {
+      document.getElementById(controls).removeAttribute('hidden');
+    }
 
     // Set focus when required
     if (setFocus) {


### PR DESCRIPTION
Actual Result: ​​​
Narrator/NVDA is reading non selected tab item as selected incorrectly with out the particular tab information is opened​
​
Expected Result:​
Narrator/NVDA shouldn't read non selected tab item as selected incorrectly with out the particular tab information is opened​

I've fixed this by making the [libraries](https://www.odata.org/libraries/) page to be similar to the [reference services](https://www.odata.org/odata-services/) page which doesn't have the issue 
Navigating across the tabs now gives the tab name but doesn't narrate it as 'selected'