### PR TITLE
Corrected aria headers

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="container">
   <div class="page-header">
-    <h1 role="heading" aria-level="1" >{{ page.title }}</h1>
+    <h1>{{ page.title }}</h1>
   </div>
   {{ content }}
 </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="container">
   <div class="page-header">
-    <h1 role="heading">{{ page.title }}</h1>
+    <h1 role="heading" aria-level="1" >{{ page.title }}</h1>
   </div>
   {{ content }}
 </div>

--- a/pages/documentation/atom-format-v2.html
+++ b/pages/documentation/atom-format-v2.html
@@ -7,16 +7,16 @@ permalink: /documentation/odata-version-2-0/atom-format/
 <h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 role="heading">Introduction</h2>
+<h2>Introduction</h2>
 <p>OData supports two formats for representing the resources (Collections, Entries, Links, etc) it exposes: the XML-based Atom format and the JSON format. This document describes how OData resources are represented in Atom (plus additional elements defined in AtomPub) and <a href="../json-format">[OData-JSON]</a> describes the JSON representation. The <a href="../operations#RepresentationFormatAndContentTypeNegotiation"> content type negotiation</a> section of the <a href="../operations">[OData-Operations]</a> document describes how clients can use standard HTTP content type negotiation to tell an OData service which format it wants to use.</p>
-<h2 role="heading">1. Background</h2>
+<h2>1. Background</h2>
 <p>As described in Atom <a href="http://tools.ietf.org/html/rfc4287">[RFC4287]</a>, Atom is an XML-based document format that describes Collections of related information known as "feeds". Feeds are composed of a number of items, known as Entries. AtomPub <a href="http://tools.ietf.org/html/rfc5023">[RFC5023]</a> defines additional format constructs for Entries and Feeds to enable the resources they represent to be easily categorized, grouped, edited and discovered. For the remainder of this document, the term Atom is used to represent the combination of the format/representation rules defined in Atom<a href="http://tools.ietf.org/html/rfc4287">[RFC4287]</a> and AtomPub <a href="http://tools.ietf.org/html/rfc5023">[RF5023]</a>.</p>
 <p>As noted in the OData Basics section of [OData:Core], OData services expose Collections of structured Entries, making Atom a natural fit for representing OData resources. Since Atom does not define how structured data is encoded with feeds, to enable transfers of structured content by OData services, this document defines a set of conventions for representing structured data in an Atom feed.</p>
 <p>It should be noted that feeds following the conventions defined in this document are valid AtomPub feeds and can be consumed by feed readers, tools, etc. which are only aware of the Atom standards ([RFC4287] &amp; [RFC5023]), but not the additional conventions defined in this document.</p>
-<h2 role="heading">2. Atom Representations</h2>
+<h2>2. Atom Representations</h2>
 <p>The following sections define how resources (Collection, Entries, etc) exposed by an OData service can be represented in requests and responses payloads using the Atom format. For details regarding how to create various request types (Retrieve, Create, etc) see <a href="../operations">[OData-Operations]</a> .</p>
 <p>Through out this section the notation <atom:elementName> is used to refer to the named element in the Atom <a href="http://tools.ietf.org/html/rfc4287">[RFC4287]</a> specification.</p>
-<h3 role="heading">2.1. Primitive Types</h3>
+<h3>2.1. Primitive Types</h3>
 <p>Values of OData primitive types are represented as values of XML elements/attributes as per the table below. Note: The type system used by OData services is described in full in the <a href="../overview#AbstractTypeSystem">primitive types</a> section of the <a href="../overview">[OData-Core]</a> document. In addition to the rules stated in the table, if the value of a primitive type is null, then it is represented as an empty XML element with an <strong>m:null="true"</strong> attribute ("m" identifies the OData metadata namespace).</p>
 <div>
 <table border="0">
@@ -88,7 +88,7 @@ permalink: /documentation/odata-version-2-0/atom-format/
 </tbody>
 </table>
 </div>
-<h3 role="heading">2.2. Service Documents</h3>
+<h3>2.2. Service Documents</h3>
 <p>As described in <a href="../overview">[OData-Core]</a>, if a service exposes several Collections, then to aid discovery of those Collections by clients it is useful for the service to expose a Service Document which lists the available Collections. Service Documents are described in AtomPub <a href="http://tools.ietf.org/html/rfc5023#page-15"> [RFC5023], section 15</a>.</p>
 <p>For example, the URI <a href="https://services.odata.org/OData/OData.svc">https://services.odata.org/OData/OData.svc</a> identifies the Service Document of a sample OData service which exposes a Categories, Products and Suppliers Collection. For convenience, a sample Service Document is shown in the listing below.</p>
 {% highlight xml %}<?xml version="1.0" encoding="utf-8" standalone="yes" ?> 
@@ -109,7 +109,7 @@ permalink: /documentation/odata-version-2-0/atom-format/
     </collection>
   </workspace>
 </service>{% endhighlight %}
-<h3 role="heading">2.3. Representing Collections of Entries</h3>
+<h3>2.3. Representing Collections of Entries</h3>
 <p><a href="../terminology#Collection">Collections</a> represent a set of <a href="../terminology#Entry">Entries</a>. In OData, Collections are represented as Atom feeds ([RFC5023] ), with one Atom entry for each Entry within the Collection. For example, a Collection of product category Entries (that could be part of a product catalog) exposed by an OData service, as identified by the URI <a href="https://services.odata.org/OData/OData.svc/Categories">https://services.odata.org/OData/OData.svc/Categories</a>, is represented as shown below. The format of <atom:entry> elements within a feed is described in the <a href="../atom-format#RepresentingEntries">Representing Entries</a> section.</p>
 <p><strong>Note</strong>: The "m" and "d" prefixes represent the OData metadata and data namespaces. It is likely the next version of OData will generalize the namespace URI to use an odata.org based URI.</p>
 
@@ -202,7 +202,7 @@ permalink: /documentation/odata-version-2-0/atom-format/
       href="https://services.odata.org/Northwind/Northwind.svc/Customers?
     $inlinecount=allpages&amp;$skiptoken='ERNSH'" /> </strong>
 </feed>{% endhighlight %}
-<h3 role="heading">2.4. Representing Entries</h3>
+<h3>2.4. Representing Entries</h3>
 <p>In OData, Entries are represented as Atom <atom:entry> elements with all the <a href="../terminology#Property">Properties</a> of the Entry represented as elements within the <m:properties> element which is a direct child of the <atom:content> element. When using an OData v2 server, clients may indicate that they want a subset of the properties by using the Select System Query Option in the request.</p>
 <p>If the Entry being represented links to other Entries via <a href="../terminology#NavigationProperty"> Navigation Properties</a> (e.g. a Product is related to a Category), then the Links are represented as <atom:link rel= <a href="http://schemas.microsoft.com/ado/2007/08/dataservices/related/%5bNavigationPropertyName%5d"> http://schemas.microsoft.com/ado/2007/08/dataservices/related/[NavigationPropertyName]</a> href=â€â€¦"/> elements â€" one for each Navigation Property of the Entry.</p>
 <p>Metadata describing the Entry being represented can be specified using additional Atom-defined and OData-defined elements/attributes as defined by the following list.</p>
@@ -256,10 +256,10 @@ permalink: /documentation/odata-version-2-0/atom-format/
     </m:properties> 
   </content></strong>
 </entry>{% endhighlight %}
-<h4 role="heading">2.4.1. Deferred Content</h4>
+<h4>2.4.1. Deferred Content</h4>
 <p>To conserve resources (bandwidth, CPU, and so on), it is generally not a good idea for an OData service to return the full graph of Entries related to the Entry (or Collection of entries) identified in a request URI. For example, an OData service should defer sending related Entries unless the client explicitly asked for them using the <a href="../uri-conventions#ExpandSystemQueryOption">$expand System Query Option</a> which provides a way for a client to state related entities should be <a href="../atom-format#InlineRepresentationofAssociatedEntries">represented inline</a>.</p>
 <p>As shown in the example in the prior section, by default properties which represent <a href="../terminology#Link">Links</a> (the "Products" property in the example) are represented as a <link rel=" <strong> </strong> http://schemas.microsoft.com/ado/2007/08/dataservices/related/[NavigationPropertyName]" href="..." /> element to indicate the service deferred representing the related Entries. If needed, a client can then use the URI in the href attribute in a subsequent retrieve request to obtain the related Entries.</p>
-<h4 role="heading">2.4.2. Inline Representation of Associated Entries</h4>
+<h4>2.4.2. Inline Representation of Associated Entries</h4>
 <p>As described in the <a href="../uri-conventions#ExpandSystemQueryOption"> $expand System Query Option section</a> of the <a href="../uri-conventions">[OData-URI]</a> document, a request URI may include the $expand query option to explicitly request that a linked to Entry or collection of Entries be serialized inline, rather than deferred.</p>
 <p>In this case the related Entry or collection of Entries is represented as the child element of an <m:inline> element as an <atom:feed> or <atom:entry> respectively. For example, a single Category Entry with its related Product Entries serialized inline is represented as shown in the example below.</p>
 {% highlight xml %}<?xml version="1.0" encoding="utf-8" standalone="yes"?>
@@ -325,7 +325,7 @@ permalink: /documentation/odata-version-2-0/atom-format/
     </m:properties>
   </content>
 </entry>{% endhighlight %}
-<h4 role="heading"> 2.4.3. Representing Media Link Entries</h4>
+<h4> 2.4.3. Representing Media Link Entries</h4>
 <p><a href="../terminology#MediaLinkEntry">Media Link Entries (MLE)</a> are represented in the same way as regular Entries as described in <a href="../atom-format#RepresentingEntries"> Representing Entries</a>; however, they also contain additional metadata per Entry that describes the Media Resource (MR) associated with the Entry and the <m:properties> element becomes a child of the <atom:entry> element. The <m:properties> element is moved out from under the <atom:content> element because in the case of an MLE, the content describes the MR.</p>
 <p>This additional MR-specific metadata is represented by the following constructs in the <atom:entry>:</p>
 <ul>
@@ -342,7 +342,7 @@ permalink: /documentation/odata-version-2-0/atom-format/
 </ul>
 </li>
 </ul>
-<h4 role="heading">2.4.4. Customizing the Representation of an Entry</h4>
+<h4>2.4.4. Customizing the Representation of an Entry</h4>
 <p>Services may wish to have more flexibility over how Entries are represented within an <atom:entry> element. For example, a service may want to enable the value of a property of an Entry be represented as the value of one of the standard Atom elements (Title, Summary, etc) or as the value of a custom element within an Entry. OData supports services that need this kind of control over the Atom representations of an Entry.</p>
 <p>In general a service may choose to deviate from the conventions defined in Representing Entries section above and represent the value of a Property of an Entry as the value of a standard Atom element (Title, Summary, etc) or as the value of an element in a custom namespace. When a service does this form of customization it breaks the shared assumption between client and server regarding how Entries are encoded within an <atom:entry> element. OData services that deviate from the prescribed encoding should expose a <a href="../terminology#ServiceMetadataDocument"> Service Metadata Document</a> that include Feed Customization annotations which allow a client to discover how the server chose to encode a given Entry within the <atom:entry> element. The remainder of this section describes the set of Feed Customization annotations that may be used.</p>
 <p>The following table lists all the Feed Customization annotations defined in OData.</p>
@@ -527,22 +527,22 @@ Supplier representation in Atom
     </m:properties>
   </content>
 </entry>{% endhighlight %}
-<h3 role="heading">2.5. Representing Primitive Properties</h3>
+<h3>2.5. Representing Primitive Properties</h3>
 <p>When represented in a request/response payload as part of an Entry, Complex Type or a standalone construct in a request payload, primitive properties are represented in Atom as child elements of an <m:properties> element (see Representing Entities) with the name equal to the element equal to the property and value of the element set to the primitive type value formatted as described by the table in the <a href="../atom-format#PrimitiveTypes"> Primitive Types</a> section above.</p>
 <p>See <a href="../atom-format#RepresentingPropertyValues">section 3.1</a> for the format of Properties when they are represented independently from their defining Entry (i.e. outside the context of the defining Entry).</p>
-<h3 role="heading">2.6. Representing Complex Type Properties</h3>
+<h3>2.6. Representing Complex Type Properties</h3>
 <p>When represented as a property of an Entry or Complex Type (also within an Entry) in a request/response payload, a property whose type is a <a href="../overview#AbstractDataModel"> complex type</a> is represented as an XML element with each property of the complex type represented as a direct child element (as described in the prior section for primitive properties). For example, the Address Complex Type of a Supplier Entry is shown in the example below.</p>
 <p>See <a href="../atom-format#xml_RepresentingComplexTypesProperties">section 3.1.2</a> for the format of Complex Type Properties when they are represented independently from their defining Entry (i.e. outside the context of the defining Entry).</p>
-<h2 role="heading">3. XML Representations</h2>
+<h2>3. XML Representations</h2>
 <p>The smallest unit of information that can be represented in Atom is an Entry. In several application scenarios it is practical to be able to identify a specific piece of information within the Entry, particularly when the entry is mapped to an application-level construct on the server. For example, a Presentation Entry may have a Property that is the abstract describing the presentation.</p>
 <p>To enable this scenario, as described in the <a href="../uri-conventions#ResourcePath"> Resource Path</a> section in the <a href="../uri-conventions">[OData-URI]</a> document, OData supports directly addressing a Property of an Entry. Since there is not a natural mapping of a single Property (outside of the context of the defining Entry) to an Atom representation, OData represents the constituent parts of an Entry using a simple XML representation, which is described by the following subsections.</p>
-<h3 role="heading"> 3.1. Representing Property Values</h3>
+<h3> 3.1. Representing Property Values</h3>
 <p>As described in the <a href="../uri-conventions#ResourcePath">Resource Path</a> section in the <a href="../uri-conventions">[OData-URI]</a> document, OData supports directly addressing a Property of an Entry. The following subsections describe how each type of Property is represented in XML.</p>
-<h4 role="heading"> 3.1.1. Representing Primitive Properties</h4>
+<h4> 3.1.1. Representing Primitive Properties</h4>
 <p>When a primitive Property is represented as a standalone construct in a response from an OData service (such as when a retrieve request is made to a URI that identifies a single Property) it is represented as a single XML element where the element name equals the name of the Property and the value of the element is the value Property value. For example, the response payload to a retrieve request that identifies the Name property of a Category Entry is represented as shown below.</p>
 {% highlight xml %}<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Name xmlns="http://schemas.microsoft.com/ado/2007/08/dataservices">Bread</Name>{% endhighlight %}
-<h4 role="heading">3.1.2. Representing Complex Types Properties</h4>
+<h4>3.1.2. Representing Complex Types Properties</h4>
 <p>When a Property whose type is a <a href="../overview#AbstractDataModel"> complex type</a> is represented as a standalone construct, such as when a retrieve request is made to a URI that identifies a single Property, it uses a single XML element with the name of the Property and child elements for each Property defined on the complex type (formatted as per this section of the prior â€œRepresenting Primitive Propertiesâ€ section). For example, the response payload to a retrieve request that identifies the Name property of a Category Entry is represented as shown below.</p>
 {% highlight xml %}<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Address p1:type="ODataDemo.Address" 
@@ -554,14 +554,14 @@ Supplier representation in Atom
   <ZipCode>98074</ZipCode>
   <Country>USA</Country>
 </Address>{% endhighlight %}
-<h4 role="heading">3.1.3. Representing the Raw value of a Property</h4>
+<h4>3.1.3. Representing the Raw value of a Property</h4>
 <p>OData services may support <a href="../uri-conventions#AddressingEntries"> addressing the entry value of a primitive Property</a> (see the description of the $value URI segment). In this case, the value is returned using the format (aka mime type) the OData service deems to be the entry format for the Property. For example, the HTTP response from the sample OData service when retrieving the Name string Property of a Category Entry is shown in the example below.</p>
 {% highlight xml %}HTTP/1.1 200 OK
 DataServiceVersion: 1.0;
 Content-Type: text/plain;charset=utf-8
 
 Food{% endhighlight %}
-<h3 role="heading">3.2. Representing Links</h3>
+<h3>3.2. Representing Links</h3>
 <p>A Link (or collection of Links) represents an associated Entry (or collection of associated Entries). As described in <a href="../operations">[OData-Operations]</a> Links can be retrieved and modified to change the associations between Entries. A single link is represented as a <d:uri> element with the value of the element set to the URI that identifies the Link. A collection of links is represented as a <d:links> element with zero or more child <d:uri> elements, where each <d:uri> element represents a Link.</p>
 <p>Note: in the paragraph above, "d" represents the <a href="../terminology#ODataDataNamespace"> OData Data Namespace</a>.</p>
 <p>For example, a link with multiplicity 1 (ex. Product is related to a <em>single</em> Supplier) would be represented in XML in a response as:</p>
@@ -579,7 +579,7 @@ Food{% endhighlight %}
   <uri>https://services.odata.org/OData/OData.svc/Products(5)</uri>
   <uri>https://services.odata.org/OData/OData.svc/Products(6)</uri>
 </links>{% endhighlight %}
-<h3 role="heading">3.3. Representing Results from Service Operations</h3>
+<h3>3.3. Representing Results from Service Operations</h3>
 <p>As described in <a href="../operations">[OData-Operations]</a> OData services may expose custom behaviors via Service Operations, which may accept input parameters identified by the request URI (as described in <a href="../uri-conventions">[OData-URI]</a>). This section specifies how the results of a Service Operation are formatted using Atom or XML. Service operations support returning:</p>
 <ul>
 <li>A single primitive value or collection of primitive values</li>

--- a/pages/documentation/batch-processing-v2.html
+++ b/pages/documentation/batch-processing-v2.html
@@ -7,14 +7,14 @@ permalink: /documentation/odata-version-2-0/batch-processing/
 <h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 role="heading">Introduction</h2>
+<h2>Introduction</h2>
 <p>The OData protocol exposes a uniform service interface to operate on collections of structured and unstructured data. <a href="../operations">[OData-Operations]</a> enumerates the set of operations supported by the uniform interface and describes a means to send one operation per HTTP request.</p>
 <p>This document builds on the <a href="../operations">[OData-Operations]</a> document and describes how an OData implementation can optionally support executing multiple operations sent in a single HTTP request through the use of Batching. This document covers both how Batch operations are represented and processed.</p>
-<h2 role="heading">1. Background</h2>
+<h2>1. Background</h2>
 <p>The OData service interface has a fixed number of operations that have uniform meaning across all the resources it can act on. These operations are retrieve, create, update and delete and they map to the GET, POST, PUT and DELETE HTTP methods. Clients query to retrieve a feed, entry, or service document by issuing an HTTP GET request against its URI as described in <a href="../operations">[OData-Operations]</a> . Clients insert, update, and delete a feed, entry or service document by issuing a POST, PUT or DELETE request against its URI as described in <a href="../operations">[OData-Operations]</a> .</p>
-<h2 role="heading"> 2. Format of a Batch Request</h2>
+<h2> 2. Format of a Batch Request</h2>
 <p>An OData Batch Request is represented as a Multipart MIME v1.0 message <a href="http://tools.ietf.org/html/rfc2046"> [RFC2046]</a>, a standard format allowing the representation of multiple parts, each of which may have a different content type, within a single request.</p>
-<h3 role="heading">2.1. Batch Request Headers</h3>
+<h3>2.1. Batch Request Headers</h3>
 <p>Batch requests allow grouping multiple operations, as described in <a href="../operations">[OData-Operations]</a> , into a single HTTP request payload.</p>
 <p>Batch Requests are submitted as a single HTTP POST request to the $batch endpoint of a service as described in <a href="../uri-conventions">[OData-URI]</a>. The batch request must contain a Content-Type header specifying a content type of "multipart/mixed" and a boundary specification. The example below shows a GUID as a boundary and "OData/OData.svc" for the URI of the service. &lt;Batch Request Body&gt; is defined in the <a href="../batch#BatchRequestBody">Batch Request Body</a> section below.</p>
 <pre>POST OData/OData.svc/$batch HTTP/1.1
@@ -27,7 +27,7 @@ Content-Type: multipart/mixed; boundary=batch_36522ad7-fc75-4b56-8c71-56071383e7
 <p>Note: The batch request boundary must be quoted if it contains any of the following special characters :</p>
 <pre>( ) &lt; &gt; @ , ; :  / " [ ] ? =</pre>
 <p>In addition to the Content-Type header, the Batch request may contain <a href="../overview#ProtocolVersioning"> DataServiceVersion headers</a> or other HTTP Headers which apply to the entire Batch Request as appropriate. In the example above, DataServiceVersion has a value of 1.0 representing the version of the OData specification used to generate the request, and MaxDataServiceVersion has a value of 2.0 representing the maximum response version the client is prepared to accept.</p>
-<h3 role="heading">2.2. Batch Request Body</h3>
+<h3>2.2. Batch Request Body</h3>
 <p>The body of a Batch Request is made up of an ordered series of retrieve operations (as described in <a href="../operations">[OData-Operations]</a> ) and/or ChangeSets. A ChangeSet is an atomic unit of work that is made up of an unordered group of one or more of the insert, update or delete operations described in <a href="/developers/protocols/operations">[OData:Operations]</a>. ChangeSets cannot contain retrieve requests and cannot be nested (i.e. a ChangeSet cannot contain a ChangeSet).</p>
 <p>In the Batch request body, each retrieve request and ChangeSet is represented as a distinct MIME part and is separated by the boundary marker defined in the Content-Type header of the request. The contents of the MIME part which represents a ChangeSet is itself a multipart MIME document with one part for each operation that makes up the ChangeSet.</p>
 <p>Each MIME part representing a retrieve request or ChangeSet within the Batch includes both Content-Type and Content-Transfer-Encoding MIME headers as seen in the examples below. The batch request boundary is the name specified in the Content-Type Header for the batch.</p>
@@ -93,7 +93,7 @@ Host: host
 
 
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b--</pre>
-<h4 role="heading"> 2.2.1. Referencing Requests in a Change Set</h4>
+<h4> 2.2.1. Referencing Requests in a Change Set</h4>
 <p>If a MIME part representing an Insert request within a ChangeSet includes a Content-ID header, then the new entity may be referenced by subsequent requests within the same ChangeSet by referring to the Content-ID value prefixed with a "$" character. When used in this way, $&lt;contentIdValue&gt; acts as an alias for the Resource Path that identifies the new entity.</p>
 <p>The example below shows a sample batch request that contains the following operations in the order listed:</p>
 <ul>
@@ -138,21 +138,21 @@ Content-Length: ###
 
 --changeset_77162fcd-b8da-41ac-a9f8-9357efbbd621-- 
 --batch_36522ad7-fc75-4b56-8c71-56071383e77b--</pre>
-<h2 role="heading"> 3. Processing a Batch Request</h2>
+<h2> 3. Processing a Batch Request</h2>
 <p>Requests within a batch are evaluated according to the same semantics used when the request appears outside of the context of a batch.</p>
 <p>The order of ChangeSets and retrieve requests within a Batch request is significant as it states the order in which the service processes the components of the Batch.  The order of requests within a ChangeSet is not significant such that a service may process the requests within a ChangeSet in any order.</p>
 <p>All operations in a ChangeSet represent a single change unit so the server must successfully process and apply all the requests in the ChangeSet or else apply none of the requests in the ChangeSet.  It is up to the service to define rollback semantics to undo any requests within a ChangeSet that may have been applied before another request in that same ChangeSet failed and thereby honor this all-or-nothing requirement.</p>
 <p>If the set of HTTP Request headers of a Batch request are valid (the Content-Type is set to multipart/mixed, etc.) the server returns a 202 Accepted HTTP response code to indicate that the request has been accepted for processing, but that the processing has not yet been completed. The requests within the Batch request body may subsequently fail or be malformed; however, this mechanism enables clients of a Batch implementation to stream the results of a Batch request without having to first wait for all requests to be processed.</p>
 <p>If the service receives a Batch request with an invalid set of headers it returns a 4xx response code and no further processing of the batch is performed.</p>
-<h2 role="heading"> 4. Format of a Batch Response</h2>
+<h2> 4. Format of a Batch Response</h2>
 <p>The format of the Batch Response mirrors that of the Batch request as described by the following subsections.</p>
-<h3 role="heading">4.1. Batch Response Headers</h3>
+<h3>4.1. Batch Response Headers</h3>
 <p>The batch response, as shown in the example below, must contain a Content-Type header specifying a content type of multipart/mixed and a batch boundary specification which may be different than the batch boundary that was used in the corresponding request.</p>
 <pre>HTTP/1.1 202 Accepted
 DataServiceVersion: 1.0
 Content-Length: 1254
 Content-Type: multipart/mixed; boundary=batch_36522ad7-fc75-4b56-8c71-56071383e77b</pre>
-<h3 role="heading"> 4.2. Batch Response Body</h3>
+<h3> 4.2. Batch Response Body</h3>
 <p>Within the body of the batch response is a response for each retrieve request and ChangeSet that was in the associated Batch request. The order of responses in the response body must match the order of requests in the Batch request. Each response includes a Content-Type header with a value of "application/http", and a Content-Transfer-Encoding MIME header with a value of "binary".</p>
 <p>A response to a retrieve request is formatted exactly as it would have appeared outside of a batch as described in <a href="../operations">[OData-Operations]</a> .</p>
 <p>The body of a ChangeSet response is either a response for all the successfully processed change request within the ChangeSet, formatted exactly as it would have appeared outside of a batch, as described in <a href="../operations">[OData-Operations]</a> , or a single response indicating a failure of the entire ChangeSet, as described in <a href="../operations">[OData-Operations]</a> .</p>

--- a/pages/documentation/json-format-v2.html
+++ b/pages/documentation/json-format-v2.html
@@ -4,18 +4,18 @@ title: JSON Format (OData Version 2.0)
 date: 2014-02-28 03:36:01.000000000 +08:00
 permalink: /documentation/odata-version-2-0/json-format/
 ---
-<h5 role="heading" class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
+<h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 role="heading">Introduction</h2>
+<h2>Introduction</h2>
 <p>OData supports two formats for representing the resources (Collections, Entries, Links, etc) it exposes: the XML-based AtomPub format and the JSON format. This document describes how OData resources are represented in JSON and <a href="../atom-format">[OData-Atom]</a> describes the AtomPub representation. The <a href="../operations#ContentTypeNegotation">content type negotiation</a> section of the <a href="../operations">[OData-Operations]</a> document describes how clients can use standard HTTP content type negotiation to tell an OData service which format it wants to use.</p>
-<h2 role="heading">1. Background</h2>
+<h2>1. Background</h2>
 <p><a href="http://www.json.org">JavaScript Object Notation (JSON)</a> is a lightweight data interchange format based on a subset of the JavaScript Programming Language standard, as specified in <a href="http://go.microsoft.com/fwlink/?LinkId=115082"> [ECMA-262]</a>. JSON is a text format that is language independent, but uses conventions that are familiar to programmers of the C-family of languages (C, C++, JavaScript, and so on). OData supports the JSON format to make consuming OData services from Javascript applications simple since JSON can be easily be turned into JavaScript objects for programmatic manipulation using the Javascript eval( ) function.</p>
-<h2 role="heading">2. Terminology</h2>
+<h2>2. Terminology</h2>
 <p>A full list of terms used by the Open Data Protocol is available on the <a href="../terminology">OData Glossary of Terms</a> page.</p>
-<h2 role="heading">3. JSON Representations</h2>
+<h2>3. JSON Representations</h2>
 <p>The following sections define how resources exposed by an OData service can be represented in requests and/or responses payloads using the JSON format. For details regarding how to create various request types (Retrieve, Create, etc) see <a href="../operations">[OData-Operations]</a> . <strong>Security Note</strong>: In responses payloads (not request payloads) all the JSON representations described in this section are wrapped by an outer most object that includes a single name/value pair. The name of the name/value pair is always "d" and the value is the JSON representation of an OData resource as described by the subsections of this document. This pattern ensures JSON payloads returned from OData services are valid JSON statements, but not valid JavaScript statements. This prevents an OData JSON response from being executed as the result of a cross site scripting (XSS) attack.</p>
-<h2 role="heading">4. Primitive Types</h2>
+<h2>4. Primitive Types</h2>
 <p>Values of an OData primitive type are represented as JSON literal values as per the table below. Note: The type system used by OData services is described in full in the <a href="../overview#AbstractTypeSystem">Abstract Type System</a> section of the <a href="../overview">[OData-Core]</a> document.</p>
 <table border="1" cellspacing="0" cellpadding="0">
 <tbody>
@@ -85,10 +85,10 @@ permalink: /documentation/odata-version-2-0/json-format/
 </tr>
 </tbody>
 </table>
-<h2 role="heading">5. Service Documents</h2>
+<h2>5. Service Documents</h2>
 <p>As described in <a href="../overview">[OData-Core]</a>, if a service exposes several Collections, then to aid discovery of those Collections by clients it is useful for the service to expose a Service Document which lists the available Collections. Service Documents are represented in JSON by an object with a single name/value pair with the name equal to "EntitySets" and the value being an array of Collection names. For example a service document with three collections would be formatted as:</p>
 {% highlight javascript %}{ "d" : { "EntitySets": ["Products", "Categories", "Suppliers"] } }{% endhighlight %}
-<h2 role="heading">6. Representing Collections of Entries</h2>
+<h2>6. Representing Collections of Entries</h2>
 <p><a href="../terminology">Collections</a> represent a set of <a href="../terminology">Entries</a>. In OData v1, Collections are represented as an array of objects, with one object for each Entry within the Collection. For example, a collection of Entries would be represented as shown below. The format of each object in the array is described in the <a href="../json-format#RepresentingEntries">Representing Entries</a> section. In OData v2, Collections are still represented as arrays, however to enable representing Collection-level metadata, the array of objects representing the set of Entries is included as the value of a "results" name/value pair.</p>
 {% highlight javascript %}OData V1: { 
   "d" : [ 
@@ -127,7 +127,7 @@ OData V2: {
     "__next": "https://services.odata.org/OData/OData.svc$skiptoken=12"
   } 
 }{% endhighlight %}
-<h2 role="heading">7. Representing Entries</h2>
+<h2>7. Representing Entries</h2>
 <p>In OData v1, Entries are represented as JSON objects with all the <a href="../terminology">properties</a> of the Entry represented as name/value pairs of the object. Alternatively, if the Entry is being represented was identified with a URI that includes a Select System Query Option, then the prior rule is relaxed such that only the properties identified by the $select query option are represented as name/value pairs. OData v2 represents Entries the same way as V1. An optional "__metadata" name/value pair is the only pair that should be included on the object that does not directly represent a Property of the Entry being represented. This name/value pair is not data, but instead, by convention defined in this document, specifies the metadata for the Entry being represented. The value of the "__metadata" name/value pair is a JSON object that contains the name/value pairs described in the table below.</p>
 <table border="1" cellspacing="0" cellpadding="0">
 <tbody>
@@ -189,9 +189,9 @@ OData V2: {
       } 
   } 
 }{% endhighlight %}
-<h2 role="heading">8. Deferred Content</h2>
+<h2>8. Deferred Content</h2>
 <p>To conserve resources (bandwidth, CPU, and so on), it is generally not a good idea for an OData service to return the full graph of Entries related to an Entry or Collection of entries as identified in a request URI. For example, an OData service should defer sending related Entries unless the client explicitly asked for them using the <a href="../uri-conventions">$expand System Query Option</a> which provides a way for a client to state related entities should be <a href="../json-format#InlineRepresentationofAssociatedEntries"> represented inline</a>. As shown in the example above, by default properties which represent <a href="../terminology">Links</a> (the "Products" property in the example) are represented as an object with a "__deferred" name/value pair to indicate the service deferred representing the related Entries. The uri name/value pair within the "__deferred" object must be provided and can be used to retrieve the deferred content.</p>
-<h2 role="heading">9. Inline Representation of Associated Entries</h2>
+<h2>9. Inline Representation of Associated Entries</h2>
 <p>As described in the <a href="../uri-conventions">$expand System Query Option section</a> of the <a href="../uri-conventions">[OData-URI]</a> document, a request URI may include the $expand query option to explicitly request that a linked to Entry or collection of Entries be serialized inline, rather than deferred. For example, a single Category Entry with its related Product Entries serialized inline as shown in the example below.</p>
 {% highlight javascript %}OData V1 and V2: { 
   "d" : { 
@@ -228,7 +228,7 @@ OData V2: {
     ] 
   } 
 } {% endhighlight %}
-<h2 role="heading">10. Representing Media Link Entries</h2>
+<h2>10. Representing Media Link Entries</h2>
 <p><a href="../terminology">Media Link Entries (MLE)</a> are represented in the same way as "plain" Entries as described in <a href="../json-format#RepresentingEntries"> Representing Entries</a>; however, they also contain additional metadata per Entry that describes the Media Resource (MR) associated with the Entry. This additional MR metadata is represented as name/value pairs of the "__metadata" object associated with the Entry.</p>
 <table border="1" cellspacing="0" cellpadding="0">
 <tbody>
@@ -259,12 +259,12 @@ OData V2: {
 </tr>
 </tbody>
 </table>
-<h2 role="heading">11. Representing Property Values</h2>
+<h2>11. Representing Property Values</h2>
 <p>As described in the <a href="../uri-conventions#ResourcePath">Resource Path</a> section in the <a href="../uri-conventions">[OData-URI]</a> document, OData supports directly addressing a Property of an Entry. The following subsections describe how each type of Property is represented in JSON.</p>
-<h2 role="heading">12. Representing Primitive Properties</h2>
+<h2>12. Representing Primitive Properties</h2>
 <p>When represented in a request/response payload as part of an Entry, Complex Type or a standalone construct in a request payload, <a href="../terminology">primitive properties</a> are represented in JSON as a name/value pair, with the name equal to the name of the property and primitive type value formatted as described by the table in the <a href="../terminology">Primitive Types</a> section above. Starting with OData V2, when a primitive property is represented as a standalone construct in a response from an OData service (such as when a retrieve request is made to a URI that identifies a single property) it is represented as the value of a "results" name/value pair. For example, the response payload to a retrieve request that identifies the Name property of a Category Entry is represented as shown below.</p>
 {% highlight javascript %}OData V2 Response Payload: { "d" : { "results": { "Name": "Bread" }{% endhighlight %}
-<h2 role="heading">13. Representing Complex Types Properties</h2>
+<h2>13. Representing Complex Types Properties</h2>
 <p>When represented as a property of an Entry or Complex Type in a request/response payload, a property whose type is a <a href="../terminology">complex type</a> is represented as a JSON object with each property of the complex type represented as a name/value pair (as described in the prior section for primitive properties). For example, the Address Complex Type of a Supplier Entry is shown in the example below. Starting with OData V2, in response payloads only, when a property whose type is a <a href="../terminology">complex type</a> is represented as a standalone construct, such as when a retrieve request is made to a URI that identifies a single property, it is represented as the value of a "results" name/value pair. For example, the response payload to a retrieve request that identifies the Name property of a Category Entry is represented as shown below.</p>
 {% highlight javascript %}OData V2 Response Payload: { 
   "d" : { 
@@ -280,11 +280,11 @@ OData V2: {
     } 
   } 
 }{% endhighlight %}
-<h2 role="heading">14. Representing the Raw value of a Property</h2>
+<h2>14. Representing the Raw value of a Property</h2>
 <p>OData services may support addressing the "raw" value of a primitive property (see the description of the $value URI segment). In this case the value is returned using the format (aka mime type) the OData service deems to be the "raw" format for the property. For example, the HTTP response from the sample OData service when retrieving the Name string property of a Category entry is shown in the example below.</p>
 {% highlight javascript %}HTTP/1.1 200 OK DataServiceVersion: 1.0; Content-Type: text/plain;charset=utf-8
   Food{% endhighlight %}
-<h2 role="heading">15. Representing Links</h2>
+<h2>15. Representing Links</h2>
 <p>A Link (or collection of Links) represents an associated Entry (or collection of associated Entries). As described in <a href="../operations">[OData-Operations]</a> Links can be retrieved and modified to change the associations between Entities. A single link is represented as a JSON object with a "uri" name/value pair with the value of the pair being the URI that identifies the Link. A collection of links is represented as a array of JSON objects with each object representing a Link. For example, a link with multiplicity 1 (ex. Product is related to a <em>single</em> Supplier) would be represented in a response as:</p>
 {% highlight javascript %}{ "d" : { "uri": "https://services.odata.org/OData/OData.svc/Suppliers(0)" } }{% endhighlight %}
 <p>For example, a link with multiplicity greater than 1 (ex. Supplier is related to <em>many</em> products) would be represented in a response as:</p>
@@ -305,7 +305,7 @@ OData V2 Response Payload: {
     "__count": "3" 
   } 
 }{% endhighlight %}
-<h2 role="heading">16. Representing Results from Service Operations</h2>
+<h2>16. Representing Results from Service Operations</h2>
 <p>As described in <a href="../operations">[OData-Operations]</a> OData service may expose custom behaviors via Service Operations. As described in <a href="../uri-conventions">[OData-URI]</a> the input parameters to Service Operations are identified by the request URI. This section specifies how the results of a Service Operation are formatted using JSON. Service operations support returning:</p>
 <ul>
 <li>A single primitive value or collection of primitive values</li>

--- a/pages/documentation/json-verbose-format-v3.html
+++ b/pages/documentation/json-verbose-format-v3.html
@@ -4,12 +4,12 @@ title: JSON Verbose Format (OData Version 3.0)
 date: 2014-02-20 08:15:04.000000000 +08:00
 permalink: /documentation/odata-version-3-0/json-verbose-format/
 ---
-<h5 class="alert alert-success" role="heading">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 3.0. 
+<h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 3.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
 <p>OData is released under the <a href="http://www.microsoft.com/openspecifications/en/us/programs/osp/default.aspx">Open Specification Promise</a> to allow anyone to freely interoperate with OData implementations.<br />
 Current Revision: 4/27/2012</p>
-<h1 id="overview" role="heading">Overview</h1>
+<h1 id="overview">Overview</h1>
 <p>The OData protocol is comprised of a set of specifications for representing and interacting with structured content. The core specification for the protocol is in core; this document is an extension of the core protocol. This document defines representations for the OData requests and responses using a verbose JSON format.</p>
 <p>An OData JSON payload may represent:</p>
 <ul>
@@ -25,20 +25,20 @@ Current Revision: 4/27/2012</p>
 <li>a set of responses returned from a batch request</li>
 </ul>
 <p>Most payloads are represented identically in requests and responses. There are some differences. This document first defines the common formats, then discusses details that are specific to request or response.</p>
-<h1 id="notationalconventions" role="heading">2. Notational Conventions</h1>
+<h1 id="notationalconventions">2. Notational Conventions</h1>
 <p>The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [<a title="Key words for use in RFCs to Indicate Requirement Levels" href="http://tools.ietf.org/html/rfc2119">RFC2119</a>].</p>
-<h2 id="normativereferences" role="heading">2.1 Normative References</h2>
+<h2 id="normativereferences">2.1 Normative References</h2>
 <ul>
 <li>Normative reference to the OData core document</li>
 <li>Normative reference to the ABNF for OData</li>
 <li>Normative reference to the JSON specification</li>
 </ul>
-<h2 id="informationalexamples" role="heading">2.2 Informational Examples</h2>
+<h2 id="informationalexamples">2.2 Informational Examples</h2>
 <p>This document contains many example JSON payloads or partial JSON payloads. These examples are informative only. The text shall be taken as the normative specification.</p>
-<h1 id="requestingverbosejsonformat" role="heading">3 Requesting Verbose JSON Format</h1>
+<h1 id="requestingverbosejsonformat">3 Requesting Verbose JSON Format</h1>
 <p>Verbose JSON is not the default OData format. To receive responses in Verbose JSON, the client MUST explicitly ask for them.</p>
 <p>To request this format using $format, use the value <code>jsonverbose</code>. To request this format using the Accept header, use the MIME type <code>application/json;odata=verbose</code>.</p>
-<h2 id="clientserviceformatcompatibilityandversions" role="heading">3.1 Client/Service Format Compatibility and Versions</h2>
+<h2 id="clientserviceformatcompatibilityandversions">3.1 Client/Service Format Compatibility and Versions</h2>
 <p>Prior to version 3.0, Verbose JSON format was simply the only OData JSON format. In version 3.0 and later, JSON is the default JSON format.</p>
 <p>A request with Accept header <code>application/json</code> or with a $format value of <code>json</code> MUST be treated as a request for the service’s default JSON format.</p>
 <p>Therefore, such a request on a version 1.0 or 2.0 service, or if specified with a MaxDataServiceVersion header of 1.0 or 2.0 will result in Verbose JSON. However, a request for default JSON on a version 3.0 or higher service with a MaxDataServiceVersion of 3.0 or higher will result in JSON</p>
@@ -56,15 +56,15 @@ Accept: application/json;odata=verbose
 Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 {% endhighlight %}
 <p>Optionally, Atom can be added as a further fallback in case the service supports neither JSON format.</p>
-<h1 id="commonpayloadformat" role="heading">4 Common Payload Format</h1>
+<h1 id="commonpayloadformat">4 Common Payload Format</h1>
 <p>This section describes the representation for OData values in Verbose JSON. A request or response body consists of several parts. It contains OData values as part of a larger document. See Request Formats and Response Formats for the specification of request and response bodies.</p>
-<h2 id="representinganentity" role="heading">4.1 Representing an Entity</h2>
+<h2 id="representinganentity">4.1 Representing an Entity</h2>
 <p>An instance of an entity type MUST be serialized as a JSON object.</p>
 <p>Each Property to be transmitted MUST be represented as a name/value pair within the object. See <a href="../json-verbose-format#representingapropertyinarequest">Representing a Property</a> for details. The order Properties appear within the object MUST be considered insignificant. Name/value pairs not representing a property defined on the entity type SHOULD NOT be included.</p>
 <p>An entity in a payload MAY be a complete entity, a projected entity (see <code>$select</code>), or a partial entity update (see Patch). A complete entity MUST transmit every property, including navigation properties. A projected entity MUST transmit the requested properties and MAY transmit other properties. A partial entity MUST transmit the properties that it intends to change; it MUST NOT transmit any other properties.</p>
 <p>The name in a property’s name/value MUST NOT be <code>__metadata</code>. There is no JSON Verbose representation for a property named <code>__metadata</code>.</p>
 <p>An entity JSON object MAY include a name/value pair named <code>__metadata</code>. This name/value pair does not represent a property. It specifies the metadata for the entity. The ordering of this name/value pair with respect to name/value pairs that represent properties MUST be considered insignificant.</p>
-<h3 id="entitymetadata" role="heading">4.1.1 Entity Metadata</h3>
+<h3 id="entitymetadata">4.1.1 Entity Metadata</h3>
 <p>The value of the <code>__metadata</code> property MUST be a JSON object.</p>
 <p>In OData 1.0 and OData 2.0, the value of the <code>__metadata</code> property contains up to seven name/value pairs: <code>uri</code>, <code>type</code>, <code>etag</code>, <code>edit_media</code>, <code>media_src</code>, <code>media_etag</code>, and <code>content_type</code>. In OData 3.0, four more name/value pairs are added: <code>properties</code>, <code>actions</code>, <code>functions</code>, and <code>id</code>. The order of these name/value pairs MUST be considered insignificant.</p>
 <p>If the entity is not a Media Link Entry, then the <code>edit_media</code>, <code>media_src</code>, <code>media_etag</code>, and <code>content_type</code> name/value pairs MUST NOT be included.</p>
@@ -76,24 +76,24 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 <p>The <code>actions</code> name/value pair MAY be included in a response if the service is advertising actions. See <a href="../json-verbose-format#entitymetadataforactions">Entity Metadata for Actions</a> for details.</p>
 <p>The <code>functions</code> name/value pair MAY be included in a response if the service is advertising functions. See <a href="../json-verbose-format#entitymetadataforfunctions">Entity Metadata for Functions</a> for details.</p>
 <p>The <code>actions</code> and <code>functions</code> name/value pairs MAY be included in request payloads. In requests they are without meaning and MUST be ignored by the service.</p>
-<h4 id="entitymetadataformedialinkentries" role="heading">4.1.1.1 Entity Metadata for Media Link Entries</h4>
+<h4 id="entitymetadataformedialinkentries">4.1.1.1 Entity Metadata for Media Link Entries</h4>
 <p>If the entity is a media link entity, the <code>media_src</code> name/value pair MUST be included and the <code>edit_media</code>, <code>content_type</code>, and <code>media_etag</code> name/value pairs MAY be included.</p>
 <p>The value of the <code>media_src</code> name/value pair MUST be the source URI for the data corresponding to this MLE.</p>
 <p>The value of the <code>content_type</code> name/value pair SHOULD be the MIME type of the data corresponding to this MLE. This is only a hint. The actual content type will be included in a header when the resource is requested.</p>
 <p>The value of the <code>edit_media</code> name/value pair MUST be the edit URI for the data corresponding to this MLE.</p>
 <p>The value of the <code>media_etag</code> name/value pair MUST be the concurrency token for the data corresponding to this MLE.</p>
-<h4 id="entitymetadataforactions" role="heading">4.1.1.2 Entity Metadata for Actions</h4>
+<h4 id="entitymetadataforactions">4.1.1.2 Entity Metadata for Actions</h4>
 <p>Starting in the OData 3.0 protocol, the <code>actions</code> name/value pair MAY be included in <code>__metadata</code>. The value is a JSON object that contains action advertisement name/value pairs. See <a href="../json-verbose-format#advertisementforafunctionoraction">Advertisement for a Function or Action</a> for details.</p>
-<h4 id="entitymetadataforfunctions" role="heading">4.1.1.3 Entity Metadata for Functions</h4>
+<h4 id="entitymetadataforfunctions">4.1.1.3 Entity Metadata for Functions</h4>
 <p>Starting in the OData 3.0 protocol, the <code>functions</code> name/value pair MAY be included in <code>__metadata</code>. The value is a JSON object that contains function advertisement name/value pairs. See <a href="../json-verbose-format#advertisementforafunctionoraction">Advertisement for a Function or Action</a> for details.</p>
 <p>The name MUST only identify functions that are bindable to the current entity type. If overloads exist that cannot be bound to the current entity type, the name SHOULD address a specific function overload.</p>
 <p>If all function overloads can be bound to the current entity type, the service SHOULD advertise a single function Metadata URL that identifies all of the overloads.</p>
-<h2 id="representinganavigationproperty" role="heading">4.2 Representing a Navigation Property</h2>
+<h2 id="representinganavigationproperty">4.2 Representing a Navigation Property</h2>
 <p>A navigation property represents a reference from a source entity to zero or more other entities.</p>
 <p>There are two representations for a navigation property: deferred and expanded. The deferred representation represents each related entity with a URI. The expanded representation represents each related entity with its expanded contents.</p>
 <p>By default, a service SHOULD represent each navigation property in the deferred format. This conserves resources.</p>
 <p>A client MAY request that a navigation property be expanded, using a combination of $expand and $select. The service MUST represent each navigation property so requested in the expanded format.</p>
-<h3 id="exampledeferrednavigationproperty" role="heading">4.2.1 Example Deferred Navigation Property</h3>
+<h3 id="exampledeferrednavigationproperty">4.2.1 Example Deferred Navigation Property</h3>
 {% highlight javascript %}{
     "CustomerID": "ALFKI",
     "Orders":  {
@@ -110,7 +110,7 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
     }
 }
 {% endhighlight %}
-<h3 id="exampleexpandednavigationproperty" role="heading">4.2.2 Example Expanded Navigation Property</h3>
+<h3 id="exampleexpandednavigationproperty">4.2.2 Example Expanded Navigation Property</h3>
 {% highlight javascript %}{
     "CustomerID": "ALFKI",
     "Orders": {
@@ -132,21 +132,21 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
     }
 }
 {% endhighlight %}
-<h3 id="representingadeferrednavigationproperty" role="heading">4.2.3 Representing a Deferred Navigation Property</h3>
+<h3 id="representingadeferrednavigationproperty">4.2.3 Representing a Deferred Navigation Property</h3>
 <p>A deferred navigation property is represented as a name/value pair. The name MUST be the name of the property. The value must be a JSON object.</p>
 <p>The value must contain a single name/value pair. This name MUST be <code>__deferred</code>. The inner value MUST be another JSON object.</p>
 <p>The inner JSON Object must contain a single name/value pair. The name must be <code>uri</code>. The value must be the URI for the navigation property (this is not the NavigationLink URI).</p>
 <p>See <a href="../json-verbose-format#exampledeferrednavigationproperty">Example Deferred Navigation Property</a> for an example.</p>
-<h3 id="representinganexpandednavigationproperty" role="heading">4.2.4 Representing an Expanded Navigation Property</h3>
+<h3 id="representinganexpandednavigationproperty">4.2.4 Representing an Expanded Navigation Property</h3>
 <p>An expanded navigation property is represented as a name/value pair. The name MUST be the name of the property.</p>
 <p>The value MUST be the correct representation of the related entity or entity set. See <a href="../json-verbose-format#representinganentity">Representing an Entity</a>, <a href="../json-verbose-format#representingmultipleentitiesinaresponse">Representing Multiple Entities in a Response</a>, or <a href="../json-verbose-format#representingmultipleentitiesinarequest">Representing Multiple Entities in a Request</a> for details.</p>
 <p>See <a href="../json-verbose-format#exampleexpandednavigationproperty">Example Expanded Navigation Property</a> for an example.</p>
-<h2 id="representingnavigationpropertymetadata" role="heading">4.3 Representing Navigation Property Metadata</h2>
+<h2 id="representingnavigationpropertymetadata">4.3 Representing Navigation Property Metadata</h2>
 <p>Metadata for a navigation property is represented as a name/value pair.</p>
 <p>The name MUST be the property’s name.</p>
 <p>The value MUST be a JSON object containing a single name/value pair. The name must be <code>associationuri</code>. The value must be a string containing the NavigationLink URI for that property.</p>
 <p>See <a href="../json-verbose-format#exampledeferrednavigationproperty">Example Deferred Navigation Property</a> for an example.</p>
-<h2 id="representinganamedresourcestreamvalue" role="heading">4.4 Representing a Named Resource Stream Value</h2>
+<h2 id="representinganamedresourcestreamvalue">4.4 Representing a Named Resource Stream Value</h2>
 <p>The value of a named resource stream property is represented like in the following example.</p>
 {% highlight javascript %}{
     "__mediaresource": {
@@ -175,9 +175,9 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 <p>The <code>content_type</code> name/value pair MUST be included. If the <code>edit_media</code> name/value pair is present the value of the <code>content_type</code> name/value pair MUST specify the content type of the binary stream represented by the <code>edit_media</code> URI. The value of the <code>content_type</code> name/value pair MAY match the content type of the binary stream represented by the <code>media_src</code> URI.</p>
 <p>The <code>edit_media</code> name/value pair MAY be included. This name/value pair MUST be supplied if the named resource stream instance can be updated. The value of the <code>edit_media</code> name/value pair MUST be a URI that can be used to replace the existing stream with a HTTP PUT request.</p>
 <p>The <code>media_etag</code> name/value pair MAY be included. When included, the value MUST be the value of the ETag for the named resource stream last PUT to the `edit_media URI.</p>
-<h2 id="representingaprimitivevalue" role="heading">4.4 Representing a Primitive Value</h2>
+<h2 id="representingaprimitivevalue">4.4 Representing a Primitive Value</h2>
 <p>The representation for primitives in JSON Verbose is specified in the ABNF.</p>
-<h2 id="representingacomplextypevalue" role="heading">4.5 Representing a Complex Type Value</h2>
+<h2 id="representingacomplextypevalue">4.5 Representing a Complex Type Value</h2>
 <p>In the following example, Address is a property with a complex type value.</p>
 {% highlight javascript %}{
     "CustomerID": "ALFKI",
@@ -186,7 +186,7 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 {% endhighlight %}
 <p>A complex type value MUST be represented as a single JSON object. It MUST have one name/value pair for each Property that makes up the complex type. Each property MUST be formatted as appropriate for the property. See <a href="../json-verbose-format#representingapropertyinarequest">Representing a Property</a> for details.</p>
 <p>The object representing a complex type value SHOULD NOT contain any other name/value pairs.</p>
-<h2 id="representingasetoflinks" role="heading">4.6 Representing a Set of Links</h2>
+<h2 id="representingasetoflinks">4.6 Representing a Set of Links</h2>
 <p>A set of links expresses a relation from one entity to zero or more related entities.</p>
 <p>The following example shows a set of links represented as appropriate for a request.</p>
 {% highlight javascript %}[
@@ -197,7 +197,7 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 <p>A set of links MUST be represented as a single JSON array. This array MUST contain one item per link.</p>
 <p>Each link item MUST be represented as a single JSON object. This object MUST contain a single name/value pair. The name MUST be <code>uri</code>. The value MUST be a URI for the related entity.</p>
 <p>There are additional considerations for representing a set of links in a response. See <a href="../json-verbose-format#representingasetoflinksinaresponse">Representing a Set of Links in a Response</a> for details.</p>
-<h2 id="representingannotations" role="heading">4.7 Representing Annotations</h2>
+<h2 id="representingannotations">4.7 Representing Annotations</h2>
 <p>Annotations MAY be applied to any name/value pair in a JSON payload that represents a value of any type from the EDM.</p>
 <p>The following example shows annotations applied to many different constructs.</p>
 {% highlight javascript %}{
@@ -224,43 +224,43 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 {% endhighlight %}
 <p>In general, it is possible to express an annotation internally or externally to a value. However, an annotation is always a name/value pair. Therefore, it can only be expressed within a JSON object. Some EDM constructs are not represented with JSON objects. Therefore some types may only be annotated externally.</p>
 <p>See the specific subsections of this section for normative rules abuot how to represent annotations on various types.</p>
-<h3 id="annotateavaluerepresentedasajsonobject" role="heading">4.7.1 Annotate a Value Represented as a JSON Object</h3>
+<h3 id="annotateavaluerepresentedasajsonobject">4.7.1 Annotate a Value Represented as a JSON Object</h3>
 <p>This section applies when annotating a name/value pair for which the value is represented as a JSON object.</p>
 <p>Each annotation MUST be applied internally. Each annotation MUST be represented as a single name/value pair.</p>
 <p>The name MUST be the fully-scoped name of the annotation. This name MUST include namespace and name, separated by a period (<code>.</code>).</p>
 <p>The value MUST be the appropriate value for the annotation.</p>
-<h3 id="annotateavaluerepresentedasajsonarrayorprimitive" role="heading">4.7.2 Annotate a Value Represented as a JSON Array or Primitive</h3>
+<h3 id="annotateavaluerepresentedasajsonarrayorprimitive">4.7.2 Annotate a Value Represented as a JSON Array or Primitive</h3>
 <p>This section applies when annotating a name/value pair for which the value is not represented as a JSON object.</p>
 <p>The set of all annotations that apply to this name/value pair MUST be applied externally. This set of annotations is represented as a single name/value pair.</p>
 <p>The name MUST be the same as the name of the name/value pair being annotated, prefixed with the at sign (<code>@</code>).</p>
 <p>The value MUST be a JSON object. Each annotation in the set MUST be represented as a single name/value pair within this object.</p>
 <p>The name MUST be the fully-scoped name of the annotation. This name MUST include namespace and name, separated by a period (<code>.</code>).</p>
 <p>The value MUST be the appropriate value for the annotation.</p>
-<h2 id="advertisementforafunctionoraction" role="heading">4.8 Advertisement for a Function or Action</h2>
+<h2 id="advertisementforafunctionoraction">4.8 Advertisement for a Function or Action</h2>
 <p>A function or action is advertised via a name/value pair. The name MUST be a Metadata URL. The value MUST be an array of JSON objects.</p>
 <p>Any number of JSON objects is allowed in this array. Each object in this array MUST have at least two name/value pairs: <code>title</code> and <code>target</code>. The order of these name/value pairs MUST be considered insignificant.</p>
 <p>The <code>target</code> name/value pair MUST contain a bound action target URL.</p>
 <p>The <code>title</code> name/value pair MUST contain the action title as a string.</p>
-<h1 id="requestspecifics" role="heading">5 Request Specifics</h1>
+<h1 id="requestspecifics">5 Request Specifics</h1>
 <p>This section describes additional payload semantics that only apply to request payloads.</p>
-<h2 id="representingapropertyinarequest" role="heading">5.1 Representing a Property in a Request</h2>
+<h2 id="representingapropertyinarequest">5.1 Representing a Property in a Request</h2>
 <p>A Property is represented as a name/value pair. The name is the Property’s name.</p>
 <p>The value for a primitive, complex type, collection, or named stream property is the property’s value. It MUST be formatted appropriately for its type.</p>
 <p>A property’s representation is always contained within a JSON object. If the request does not already contain a wrapping JSON object, then one is wrapped around the described name/value pair.</p>
-<h2 id="representingmultipleentitiesinarequest" role="heading">5.2 Representing Multiple Entities in a Request</h2>
+<h2 id="representingmultipleentitiesinarequest">5.2 Representing Multiple Entities in a Request</h2>
 <p>A collection of entities MUST be represented as a JSON array. Each element MUST be a correctly formatted entity (see <a href="../json-verbose-format#representinganentity">Representing an Entity</a>).</p>
 <p>An empty entity set or collection of entities (one that contains no entity type instances) MUST be represented as an empty JSON array.</p>
-<h2 id="representingacollectionofcomplextypeorprimitivevaluesinarequest" role="heading">5.3 Representing a Collection of Complex Type or Primitive Values in a Request</h2>
+<h2 id="representingacollectionofcomplextypeorprimitivevaluesinarequest">5.3 Representing a Collection of Complex Type or Primitive Values in a Request</h2>
 <p>A collection of complex type or primitive values MUST be represented as a JSON array. Each element in the array MUST be the representation for a value. See <a href="../json-verbose-format#representingaprimitivevalue">Representing a Primitive Value</a> or <a href="../json-verbose-format#representingacomplextypevalue">Representing a Complex Type Value</a> for details.</p>
-<h1 id="responsespecifics" role="heading">6 Response Specifics</h1>
+<h1 id="responsespecifics">6 Response Specifics</h1>
 <p>This section describes additional payload semantics that only apply to response payloads.</p>
-<h2 id="responsebody" role="heading">6.1 Response body</h2>
+<h2 id="responsebody">6.1 Response body</h2>
 <p>All JSON Verbose responses are wrapped in a single object for security reasons.</p>
 <p>Each response body MUST be represented as a single JSON object. This object contains a single name/value pair. The name MUST be <code>d</code>. The value MUST be the correct representation for the data being returned.</p>
-<h2 id="mimetype" role="heading">6.2 MIME Type</h2>
+<h2 id="mimetype">6.2 MIME Type</h2>
 <p>Verbose JSON is represented with a Content-Type of “application/json;odata=verbose”.</p>
 <p>In OData 1.0 and 2.0, it was also represented with a Content-Type of “applicaton/json”. However, in OData 3.0, “application/json” has been redefined to mean JSON.</p>
-<h2 id="representingapropertyinaresponse" role="heading">6.3 Representing a Property in a Response</h2>
+<h2 id="representingapropertyinaresponse">6.3 Representing a Property in a Response</h2>
 <p>In OData 1.0, a property in a response is formatted just like in a request. See <a href="../json-verbose-format#representingapropertyinarequest">Representing a Property in a Request</a> for details.</p>
 <p>Additionally, any property that is being represented as part of a larger item is represented as in a request.</p>
 <p>The rest of this section applies only to representing a top-level property in OData 2.0 and 3.0.</p>
@@ -273,7 +273,7 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 {% endhighlight %}
 <p>A property is represented as a JSON object with a single name/value pair. The name is <code>results</code>. The value is a JSON object.</p>
 <p>The object contains the representation that would be used for this property in a request. See <a href="../json-verbose-format#representingapropertyinarequest">Representing a Property in a Request</a> for details.</p>
-<h2 id="representingmultipleentitiesinaresponse" role="heading">6.3 Representing Multiple Entities in a Response</h2>
+<h2 id="representingmultipleentitiesinaresponse">6.3 Representing Multiple Entities in a Response</h2>
 <p>In OData 1.0, a collection of entities in a response is formatted just like in a request. See <a href="../json-verbose-format#representingmultipleentitiesinarequest">Representing Multiple Entities in a Request</a> for details.</p>
 <p>The rest of this section applies to OData 2.0 and 3.0 only.</p>
 <p>A collection of entities is represented as in the following example.</p>
@@ -294,15 +294,15 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 <p>The <code>__next</code> name/value pair MAY be included. If provided, its value MUST be a string containing a URL. If provided, then the response MUST be interpreted as a partial result. The client MAY request this URL if it wishes to receive the next part of the collection or entity set.</p>
 <p>The <code>__metadata</code> name/value pair MAY be included. If provided, its value MUST be a JSON object. This object represents the metadata for the set of entities.</p>
 <p>An empty collection of entities (one that contains no entity type instances) MUST be represented as a JSON object with a <code>results</code> name/value pair. The <code>results</code> name/value pair MUST be an empty JSON array.</p>
-<h2 id="representingactionsboundtomultipleentities" role="heading">6.3.1 Representing Actions Bound to Multiple Entities</h2>
+<h2 id="representingactionsboundtomultipleentities">6.3.1 Representing Actions Bound to Multiple Entities</h2>
 <p>In the ODATA 3.0 protocol, it is possible to advertise actions that are bound to the definition of a set of entities.</p>
 <p>Actions are advertised in the metadata for a set of entities. The metadata object MAY contain an <code>actions</code> name/value pair. The value is a JSON object that contains action advertisement name/value pairs. See <a href="../json-verbose-format#advertisementforafunctionoraction">Advertisement for a Function or Action</a> for details.</p>
-<h2 id="representingfunctionsboundtomultipleentities" role="heading">6.3.2 Representing Functions Bound to Multiple Entities</h2>
+<h2 id="representingfunctionsboundtomultipleentities">6.3.2 Representing Functions Bound to Multiple Entities</h2>
 <p>In the ODATA 3.0 protocol, it is possible to advertise functions that are bound to the definition of a set of entities.</p>
 <p>Functions are advertised in the metadata for a set of entities. The metadata object MAY contain a <code>functions</code> name/value pair. The value is a JSON object that contains function advertisement name/value pairs. See <a href="../json-verbose-format#advertisementforafunctionoraction">Advertisement for a Function or Action</a> for details.</p>
 <p>The function metadata URL MUST identify only functions that are bindable to the current feed definition. If overloads exist that cannot be bound to the current feed definition, the name SHOULD address a specific function overload.</p>
 <p>If all function overloads can be bound to the current feed definition, the service SHOULD advertise a single function metadata URL that identifies all of the overloads.</p>
-<h2 id="representingasetoflinksinaresponse" role="heading">6.4 Representing a Set of Links in a Response</h2>
+<h2 id="representingasetoflinksinaresponse">6.4 Representing a Set of Links in a Response</h2>
 <p>In OData 1.0 responses, a set of Links is represented exactly as described in <a href="../json-verbose-format#representingasetoflinks">Representing a Set of Links</a>.</p>
 <p>In OData 2.0 and 3.0 responses, a set of Links is represented as shown in the following example.</p>
 {% highlight javascript %}{
@@ -314,14 +314,14 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 {% endhighlight %}
 <p>A set of Links MUST be formatted as a single JSON object. This object MUST contain a name/value pair. The name MUST be <code>results</code>. The value MUST be the JSON array used to represent that set of Links in a request. See <a href="../json-verbose-format#representingasetoflinks">Representing a Set of Links</a> for details.</p>
 <p>The outer JSON object MAY contain additional name/value pairs. One such example is the <a href="../json-verbose-format#representingmultipleentitiesinaresponse">Inline Count</a>.</p>
-<h2 id="representingacollectionofcomplextypeorprimitivevaluesinaresponse" role="heading">6.5 Representing a Collection of Complex Type or Primitive Values in a Response</h2>
+<h2 id="representingacollectionofcomplextypeorprimitivevaluesinaresponse">6.5 Representing a Collection of Complex Type or Primitive Values in a Response</h2>
 <p>In OData 1.0, collection of complex type or primitive values in a response is formatted just like in a request. See <a href="../json-verbose-format#representingacollectionofcomplextypeorprimitivevaluesinaresponse">Representing a Collection of Complex Type or Primitive Values in a Response</a> for details.</p>
 <p>The rest of this section applies to OData 2.0 and 3.0 only.</p>
 <p>An collection of complex type or primitive values MUST be represented as a JSON object. This object MUST contain a <code>results</code> name/value pair. It MAY contain a <code>__metadata</code> name/value pair.</p>
 <p>The <code>results</code> value MUST be a JSON array. Each element MUST be a correctly formatted value (see <a href="../json-verbose-format#representingacomplextypevalue">Representing a Complex Type Value</a> or <a href="../json-verbose-format#representingaprimitivevalue">Representing a Primitive Value</a>).</p>
 <p>The <code>__metadata</code> name/value pair MAY be included. If provided, its value MUST be a JSON object. This object represents the metadata for the collection of complex type values.</p>
 <p>An empty collection (one that contains no instances) MUST be represented as a JSON object with a <code>results</code> name/value pair. The <code>results</code> name/value pair MUST be an empty JSON array.</p>
-<h2 id="representingerrorsinaresponse" role="heading">6.6 Representing Errors in a Response</h2>
+<h2 id="representingerrorsinaresponse">6.6 Representing Errors in a Response</h2>
 <p>Top-level errors in JSON Verbose responses MUST be represented as in the following example.</p>
 {% highlight javascript %}{
     "error": {
@@ -342,7 +342,7 @@ Accept: application/json;odata=light;q=1,application/json;odata=verbose;q=0.5
 <p>The value for the <code>code</code> name/value pair MUST be a string. Its value MUST be a service-defined error code. This code serves as a sub-status for the HTTP error code specified in the response.</p>
 <p>The value for the <code>message</code> name/value pair MUST be an object. This object MUST have two name/value pairs, with names <code>lang</code> and <code>message</code>. The <code>message</code> name/value pair MUST contain a human-readable representation of the error. The <code>lang</code> name/value pair MUST contain the language code from [[RFC 4646]][] corresponding to the language in which the value for <code>message</code> is written.</p>
 <p>The value for the <code>innererror</code> name/value pair MUST be an object. The contents of this object are service-defined. Usually this object contains information that will help debug the service.</p>
-<h2 id="representingtheservicedocument" role="heading">6.7 Representing the Service Document</h2>
+<h2 id="representingtheservicedocument">6.7 Representing the Service Document</h2>
 <p>The root URL of an OData service MUST identify a service document. This document is represented as show in the following example.</p>
 {% highlight javascript %}{
     "EntitySets": [

--- a/pages/documentation/operations.html
+++ b/pages/documentation/operations.html
@@ -7,11 +7,11 @@ permalink: /documentation/odata-version-2-0/operations/
 <h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 role="heading">Introduction</h2>
+<h2>Introduction</h2>
 <p>The OData protocol exposes a uniform service interface to operate on collections of structured and unstructured data. Most of the semantics of operations in OData come from the AtomPub protocol [RFC5023], which in turn builds on top of HTTP <a href="http://www.ietf.org/rfc/rfc2616.txt">[RFC2616]</a>.</p>
 <p>This document describes the operation model for the protocol, specifying the interactions between clients and servers for retrieving and manipulating data in an OData service. It builds on the <a href="../overview">[OData-Core]</a> document for core concepts, <a href="../uri-conventions">[OData-URI]</a> for URI conventions and on the formats specifications for Atom <a href="https://www.odata.org/developers/protocols/atom-format"> [OData-Atom]</a> and JSON <a href="../json-format">[OData-JSON]</a> for the description of data representations.</p>
-<h2 role="heading">1. Background</h2>
-<h3 role="heading">1.1 Representation formats and content type negotiation</h3>
+<h2>1. Background</h2>
+<h3>1.1 Representation formats and content type negotiation</h3>
 <p>OData supports two formats for representing resources, the XML-based Atom format and the JSON format. As described in the HTTP specification <a href="http://www.ietf.org/rfc/rfc2616.txt"> [RFC2616]</a>, clients can indicate their preference of resource representation by including an <em>accept</em> request header with a list of MIME types it can handle.</p>
 <p>A client that wants only JSON responses would set this header to "application/json". For example:</p>
 <pre><code>GET /OData/OData.svc/Products HTTP/1.1 host: services.odata.org accept: application/json</code></pre>
@@ -22,19 +22,19 @@ permalink: /documentation/odata-version-2-0/operations/
 <p>If a request does not have an <em>accept</em> header servers should default to the Atom representation.</p>
 <p>Since in certain scenarios it is not possible for clients to control request headers, OData also has an optional query string option called $format that can be used to override the value of the request header (e.g. $format=json or $format=atom). This option is further described in <a href="../uri-conventions">[OData-URI]</a>.</p>
 <p>When sending a resource as part of a request or a response body, clients and servers should set the corresponding MIME type in the <em>content-type</em> header.</p>
-<h3 role="heading">1.2 Additional considerations on the use of HTTP</h3>
+<h3>1.2 Additional considerations on the use of HTTP</h3>
 <p>OData heavily builds on HTTP for its interaction model. In addition to content-type negotiation clients and servers should use HTTP mechanisms for aspects such as character set negotiation (through accept-charset and content-type headers), caching and redirection.</p>
 <p>Similarly, while this specification uses specific status codes for specific outcomes for a request, clients should be prepared to handle all HTTP status codes and interpret them appropriately.</p>
-<h3 role="heading">1.3 Error Conditions</h3>
+<h3>1.3 Error Conditions</h3>
 <p>Error conditions are in general exposed as HTTP responses with error status codes (4xx and 5xx). Individual descriptions of operations in this specification do not call out error conditions. Servers should map error conditions to HTTP status codes. Common examples include using 404 (Not Found) when receiving requests against a URI not defined by this server, 400 for a general error in the request and 500 for a server-side error while processing the request.</p>
 <p>Clients should be prepared to handle HTTP error codes in all requests.</p>
 <p>In addition to the status code, servers should include a response body for error responses that includes more information about the error condition. The level of detail and nature of the information should be appropriate for the level of exposure of the service so as not to expose sensitive information to untrusted clients. The format for error messages is described in <a href="https://www.odata.org/developers/protocols/atom-format"> [OData-Atom]</a> and <a href="../json-format">[OData-JSON]</a>.</p>
-<h3 role="heading">1.4 Protocol Versioning</h3>
+<h3>1.4 Protocol Versioning</h3>
 <p>In order to provide a safe mechanism for evolution of the protocol OData has a versioning scheme. While OData is designed such that it can operate to certain extent without the use of version headers, clients and servers are strongly encouraged to follow the protocol versioning scheme. Details of OData versioning are covered in <a href="../overview">[OData-Core]</a>.</p>
 <p>All the examples in this document assume clients and servers that use version 2.0 of the protocol.</p>
-<h2 role="heading">2. Operations</h2>
+<h2>2. Operations</h2>
 <p>The OData service interface has a fixed number of operations that have uniform meaning across all the resources it can act on. These operations are retrieve, create, update and delete and they map to the GET, POST, PUT/MERGE and DELETE HTTP methods. Each of them acts on a resource that is indicated using a URI. In addition to the uniform interface operations, OData allows servers to expose custom operations (known as Service Operations) that can be invoked through GET or POST.</p>
-<h3 role="heading">2.1 Retrieving feeds, Entries and service document</h3>
+<h3>2.1 Retrieving feeds, Entries and service document</h3>
 <p>Clients retrieve a feed, Entry or service document by issuing an HTTP GET request against its URI. Servers respond with the feed, Entry or service document in the response body in the proper format. For example, to request the feed of products in the Atom-based format from an example product catalog OData service and its corresponding response:</p>
 <p>Request:</p>
 <pre><code>GET /OData/OData.svc/Products HTTP/1.1 Host: services.odata.org 
@@ -93,7 +93,7 @@ permalink: /documentation/odata-version-2-0/operations/
 <p>While in many cases clients will directly follow links provided externally or found in a service document to find and retrieve a feed for a Collection, often a client will want to further control how the feed is returned. OData provide a series of optional conventions to allow clients to filter, sort and page over data in Collections, we well as to request for a subset of the properties to be sent and to expand related entries inline. All these options are discussed in <a href="../uri-conventions">[OData-URI]</a>. An example on this would be (before escaping the URL):</p>
 <p>https://services.odata.org/OData/OData.svc/Products?$filter=Rating gt 2&amp;$orderby=Price&amp;$select=Rating,Price</p>
 <p>this requests all products with a Rating greater than 2, sorted by Price in ascending order, and asks the server to only retrieve the Rating and Price properties.</p>
-<h3 role="heading"> 2.2 Retrieving individual properties</h3>
+<h3> 2.2 Retrieving individual properties</h3>
 <p>Servers may support retrieval of individual properties within Entries. OData provides two ways of exposing individual properties, one that follows OData formats and another one that exposes the raw value of the property.</p>
 <p>When using the optional OData URL conventions, the former has an address that follows the containing Entry with the property name (e.g. Products(1)/Description to obtain the value of the "Description" property), and the latter uses a $value suffix (e.g. Products(1)/Description/$value). More details in the Resource Path section of the <a href="../uri-conventions">[OData-URI]</a> document.</p>
 <p>To retrieve a property value using one of the OData formats a client issues an HTTP request against the property URI, and uses content-type negotiation to indicate the expected format. Since sub-Entry elements such as properties aren't represented as whole Atom Entries, clients that use the Atom format should use "application/xml" as the content type and should be prepared to handle an XML response that is not an Atom feed or Entry. This is described in further detail in <a href="../atom-format">[OData-Atom]</a>. An example of a request to retrieve the "Description" property in a Product resource follows.</p>
@@ -114,10 +114,10 @@ permalink: /documentation/odata-version-2-0/operations/
 <p>Response:</p>
 <pre><code>HTTP/1.1 200 OK Content-Length: 12 Date: Sat, 27 Feb 2010 21:16:05 GMT Content-Type:
   text/plain;charset=utf-8 DataServiceVersion: 1.0; Low fat milk </code></pre>
-<h3 role="heading"> 2.3 Retrieving the metadata document</h3>
+<h3> 2.3 Retrieving the metadata document</h3>
 <p>Servers may expose a metadata document that describes the structure of the service and its resources. Conventionally this document is located at the /$metadata address relative to the service root URI of the service. OData metadata documents are discussed in <a href="../overview">[OData-Core]</a>.</p>
 <p>Clients can obtain the metadata document by issuing an HTTP GET request against the metadata URI. Since only an XML serialization of EDM schemas exist currently, no content-type negotiation is supported for this resource. Other HTTP aspects such as caching and character set encoding still apply.</p>
-<h3 role="heading">2.4 Creating new Entries</h3>
+<h3>2.4 Creating new Entries</h3>
 <p>Following the AtomPub protocol, new Entries are created by executing an HTTP POST request against the URI of the Collection where the Entry is to be created. The POST request includes the new Entry in its body, in one of the supported formats. For example:</p>
 <pre><code>POST /OData/OData.svc/Categories HTTP/1.1 Host: services.odata.org 
   DataServiceVersion: 1.0 MaxDataServiceVersion: 2.0 accept: application/atom+xml 
@@ -272,12 +272,12 @@ permalink: /documentation/odata-version-2-0/operations/
     &lt;/m:properties&gt; 
   &lt;/content&gt; 
 &lt;/Entry&gt;</code></pre>
-<h3 role="heading"> 2.5 Creating Media Link Entries (MLEs)</h3>
+<h3> 2.5 Creating Media Link Entries (MLEs)</h3>
 <p>Media Link Entries (MLEs) are created by issuing a POST request against the collection the MLE should be created in, with the request body containing the Media Resource (MR) and the Content-Type header indicating its media type.</p>
 <p>As described in AtomPub, servers should create both the MR and the MLE during the execution of the POST request, and return the URI of the MLE in the Location response header.</p>
 <p>OData servers usually initialize the structured data in the MLE by using server-generated values and information extracted from the MR. The MLE can optionally be included in the response body to update client state with server-generated information. Servers may return 201 (Created) or 200 (OK) when the MLE and MR were successfully created and a response body is returned, or 204 (No Content) if creation is successful but no response is returned.</p>
 <p>Use of the <em>slug</em> header as defined in AtomPub, section 9.7 is supported and has no further semantics than those defined in that specification.</p>
-<h3 role="heading">2.6 Updating Entries</h3>
+<h3>2.6 Updating Entries</h3>
 <p>To update the data in an Entry clients execute an HTTP PUT request against the Entry's URI, with a new Entry resource included in the request body.</p>
 <p>According to the AtomPub protocol specification, the PUT request replaces the existing Entry, so all property values in the Entry either take the values indicated in the request body, or are reset to their default value if not mentioned in the request. For example, to update a product in the sample OData service:</p>
 <p>Request:</p>
@@ -341,7 +341,7 @@ permalink: /documentation/odata-version-2-0/operations/
 &lt;/Entry&gt;</code></pre>
 <p>While there is a distinction between PUT and MERGE for properties, the Links of an Entry are not directly considered part of the structured data portion of an Entry and thus are not reset on PUT. Servers should use MERGE semantics for Links for both PUT and MERGE requests.</p>
 <p>NOTE: there is active discussion in the community about the introduction of a PATCH method in HTTP. Once PATCH is an official part of the HTTP specification OData will support PATCH and phase out the custom MERGE method over time.</p>
-<h3 role="heading"> 2.7 Updating individual properties</h3>
+<h3> 2.7 Updating individual properties</h3>
 <p>It is also possible to update individual properties using the same addresses a client can use to retrieve them. Clients may use the PUT method to update the value of a property. Similarly for the retrieve case, clients can choose to use URIs that point to the property in its OData format or in raw form.</p>
 <p>For example, to update only the rating of a product:</p>
 <pre><code>PUT /OData/OData.svc/Products(1)/Rating HTTP/1.1 Host: services.odata.org DataServiceVersion:
@@ -358,14 +358,14 @@ permalink: /documentation/odata-version-2-0/operations/
   content-type: text/plain Content-Length: 1 5</code></pre>
 <p>In either case servers should update the property and return 204 (No Content) and no response body or 200 (OK) and an update of the property as appropriate.</p>
 <p>Since properties are considered atomic elements (no sub-property operations exist) the MERGE method is not defined for individual properties and servers should fail requests with this method with status code 405 (Method Not Allowed).</p>
-<h3 role="heading">2.8 Deleting Entries</h3>
+<h3>2.8 Deleting Entries</h3>
 <p>Entries are deleted by executing an HTTP DELETE request against a URI that points at the Entry. If the operation executed successfully servers should return 200 (OK) with no response body.</p>
 <p>If the Entry has dependent Entries such as Entries Linked to it, it is up to the server whether deletion should be cascaded, the operation should fail because of the presence of dependent Entries, or if Links are left dangling after the Entry is deleted. This largely depends on the server, storage model and the actual application the OData service is a part of.</p>
 <p>In the case of Media Link Entries, deleting the Media Link Entry also deletes the Media Resource.</p>
-<h3 role="heading">2.9 Manipulating Links</h3>
+<h3>2.9 Manipulating Links</h3>
 <p>OData provides two ways to manipulate Links: through Link constructs in Entries and by operating on the Link resources directly.</p>
 <p>While manipulating Links by updating the Entries at either end can be simpler, this mechanism is less expressive and it is sometimes required to use Link addresses directly. For example, to add or remove a Link between two existing Entries where the Link has a cardinality of "many" on both ends (modeling a many-to-many relationship) requires the use of operations on Links directly.</p>
-<h3 role="heading"> 2.10 Creating Links between Entries</h3>
+<h3> 2.10 Creating Links between Entries</h3>
 <p>A new Link between two Entries can be established by referencing one Entry during creation or modification of another Entry (as described in <a href="../operations#CreatingnewEntries"> Creating new Entries</a> and <a href="../operations#UpdatingEntries">Updating Entries</a> ) or by explicitly issuing a POST request against the URL of the Link resource. The request must have the new URI in the request body following the appropriate format for stand-alone Links in XML or JSON as described in <a href="../atom-format">[OData-Atom]</a> and <a href="../json-format">[OData-JSON]</a>.</p>
 <p>Servers acknowledge the creation of the Link by returning a status code of 204 (No Content) and no response body. For example, to add a Link to an existing product to the list of products (through the "products" Link) of a given product category:</p>
 <p>Request:</p>
@@ -379,7 +379,7 @@ permalink: /documentation/odata-version-2-0/operations/
 <pre><code>HTTP/1.1 204 No Content Date: Tue, 02 Mar 2010 08:59:32 GMT DataServiceVersion: 1.0;</code></pre>
 <p>If using the OData URI conventions described in <a href="../uri-conventions">[OData-URI]</a>, the Link resource address can be derived by using the convention; otherwise it needs to be obtained from the Entry itself.</p>
 <p>Adding a Link using POST may result in only the new Link being added or it may have further side-effects. In particular, if the other end of the Link has a cardinality of 1, then the server may remove a previously existing Link (if any) in order to create this one and still satisfy the cardinality constrain.</p>
-<h3 role="heading"> 2.11 Removing Links between Entries</h3>
+<h3> 2.11 Removing Links between Entries</h3>
 <p>Existing Links may be removed by executing a DELETE request against the Link URI. Servers respond with the success status code of 204 (No Content) and no response body. For example, to delete the Link between a product and it's containing product category:</p>
 <p>Request:</p>
 <pre><code>DELETE /OData/OData.svc/Categories(1)/$links/Products(10) HTTP/1.1 Host: services.odata.org
@@ -388,7 +388,7 @@ permalink: /documentation/odata-version-2-0/operations/
 <pre><code>HTTP/1.1 204 No Content Date: Tue, 02 Mar 2010 09:09:02 GMT DataServiceVersion: 1.0;</code></pre>
 <p>Removing Links may cause further side-effects on the server. For example servers may cascade the deletion to the Entry or Entries the Link pointed to.</p>
 <p>Besides regular failures due to request correctness or permissions, the server may fail a DELETE request against a Link if deleting the Link would put the service data set in an inconsistent state (i.e. a state that is not allowed by the service schema).</p>
-<h3 role="heading"> 2.12 Replacing Links between Entries</h3>
+<h3> 2.12 Replacing Links between Entries</h3>
 <p>Clients may replace a Link with a new Link by issuing an HTTP PUT request against the Link resource URI, with the new URI in the request body following the appropriate format for stand-alone Links in XML or JSON as described in <a href="../atom-format">[OData-Atom]</a> and <a href="../json-format">[OData-JSON]</a>. Servers should update the Link if the service constraints allow it and return 204 (No Content). For example, to move a product from the product category with key "1" to the category with key "2":</p>
 <p>Request:</p>
 <pre><code>PUT /OData/OData.svc/Products(1)/$links/Category HTTP/1.1 Host: services.odata.org
@@ -416,7 +416,7 @@ permalink: /documentation/odata-version-2-0/operations/
 <p>Response:</p>
 <pre><code>HTTP/1.1 204 No Content Date: Tue, 02 Mar 2010 20:06:12 GMT DataServiceVersion: 1.0;</code></pre>
 <p>Since this is a merge operation and no actual properties are mentioned, the server should only update the Links included in the request body.</p>
-<h3 role="heading"> 2.13 Invoking Service Operations</h3>
+<h3> 2.13 Invoking Service Operations</h3>
 <p>Service Operations expose custom behaviors that do not map to the uniform interface. Service operations can be defined to take parameters, which are simple scalar values of one of the EDM primitive types as defined in <a href="../overview">[OData-Core]</a>.</p>
 <p>Clients may invoke a Service Operation by issuing an HTTP GET or POST request against their URI. If a particular Service Operation takes parameters they should be included as part of the query string in the request URI as described in the Addressing Service Operations section of <a href="../uri-conventions">[OData-URI]</a>. The name of each parameter is used as the name of the query string parameter, and its value should be in OData literal form. No "$" prefix should be used in parameters ("$" is reserved for OData parameters). For example:</p>
 <p>Request:</p>
@@ -441,8 +441,8 @@ https://services.odata.org/(S(dwaygaylwritgwuiyvfad5ln))/odata/odata.svc/GetProd
 &lt;/feed&gt;</code></pre>
 <p>Server implementations should only allow invocation of Service Operations through GET when the operations will not cause side-effects in the system.</p>
 <p>Service authors can choose to enable query composition in Service Operations if the operation returns a Collection of Entries. When that is the case, clients may use the URI conventions defined in <a href="../uri-conventions">[OData-URI]</a> treating the URI to the Service Operation as the URI to the initial collection, and then applying the convention from there.</p>
-<h2 role="heading">3. Additional Interaction Model Considerations</h2>
-<h3 role="heading"> 3.1 Concurrency control and ETags</h3>
+<h2>3. Additional Interaction Model Considerations</h2>
+<h3> 3.1 Concurrency control and ETags</h3>
 <p>OData uses HTTP ETags for optimistic concurrency control. A few special considerations apply for ETags:</p>
 <ul>
 <li>When retrieving an Entry the server returns an opaque ETag value
@@ -460,11 +460,11 @@ https://services.odata.org/(S(dwaygaylwritgwuiyvfad5ln))/odata/odata.svc/GetProd
 </li>
 </ul>
 <p>OData servers will use weak ETags often as a way of indicating that two resources may be semantically equivalent but a particular request may see a different representation of it. Clients should be prepared to handle weak and strong ETags.</p>
-<h3 role="heading"> 3.2 Method Tunneling through POST</h3>
+<h3> 3.2 Method Tunneling through POST</h3>
 <p>In many scenarios clients are limited to the HTTP GET and POST methods only. In order to help work-around this limitation, OData servers can support method tunneling through POST. The methods that can be executed through tunneling are MERGE, PUT and DELETE.</p>
 <p>To issue a request with method tunneling a client sets up a request with body and headers as needed, but uses POST as the HTTP method instead of the actual required one. It then adds one more header, "X-HTTP-Method", and gives it the value MERGE, PUT or DELETE.</p>
 <p>Servers must check if POST requests have the X-HTTP-Method header set to one of the valid values and if so execute the rest of the request as if the header value was the actual HTTP method for it.</p>
-<h3 role="heading"> 3.3 Processing entries of open types</h3>
+<h3> 3.3 Processing entries of open types</h3>
 <p>As discussed in <a href="../overview">[OData-Core]</a> the OData data model supports open types for Entries. An entry of an open type may have extra properties (dynamic properties) in addition to those statically declared in metadata.</p>
 <p>In general servers should treat dynamic properties and static properties as uniformly as possible.</p>
 <p>For data retrieval servers should include dynamic and static properties in entries and should use the same format for both, as discussed in <a href="../atom-format">[OData-Atom]</a> and <a href="../json-format">[OData-JSON]</a>.</p>

--- a/pages/documentation/uri-conventions.html
+++ b/pages/documentation/uri-conventions.html
@@ -7,12 +7,12 @@ permalink: /documentation/odata-version-2-0/uri-conventions/
 <h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 role="heading">Introduction</h2>
+<h2>Introduction</h2>
 <p>The Open Data Protocol (OData) enables the creation of REST-based data services, which allow resources, identified using Uniform Resource Identifiers (URIs) and defined in a <a href="../overview#ODataBasics">data model</a>, to be published and edited by Web clients using simple HTTP messages. This specification defines a set of recommended (but not required) rules for constructing URIs to identify the data and metadata exposed by an OData server as well as a set of reserved URI query string operators, which if accepted by an OData server, MUST be implemented as required by this document.</p>
 <p>The <a href="../atom-format">[OData:Atom]</a> and <a href="../json-format">[OData:JSON]</a> documents specify the format of the resource representations that are exchanged using OData and the <a href="../operations">[OData:Operations]</a> document describes the actions that can be performed on the URIs (optionally constructed following the conventions defined in this document) embedded in those representations.</p>
 <p>It is encouraged that servers follow the URI construction conventions defined in this specification when possible as such consistency promotes an ecosystem of reusable client components and libraries.</p>
 <p>The terms used in this document are defined in the <a href="../terminology">[OData:Terms]</a> document.</p>
-<h2 role="heading">1. URI Components</h2>
+<h2>1. URI Components</h2>
 <p>A URI used by an OData service has up to three significant parts: the <a href="../uri-conventions#ServiceRootUri"> service root URI</a>, <a href="../uri-conventions#ResourcePath">resource path</a> and <a href="../uri-conventions#QueryStringOptions"> query string options</a>. Additional URI constructs (such as a fragment) MAY be present in a URI used by an OData service; however, this specification applies no further meaning to such additional constructs.</p>
 <p><a href="/assets/ODataUri.png"><img src="/assets/ODataUri.png" alt="ODataUri" width="714" height="32" class="aligncenter size-full wp-image-1831" /></a></p>
 <p>The following are two example URIs broken down into their component parts:</p>
@@ -22,7 +22,7 @@ https://services.odata.org/OData/OData.svc/Category(1)/Products?$top=2&amp;$orde
 _______________________________________/ __________________/  _________________/
                    |                                |                    |
              service root URI                  resource path        query options</pre>
-<h2 role="heading">2. Service Root URI</h2>
+<h2>2. Service Root URI</h2>
 <p>The service root URI identifies the root of an OData service. The resource identified by this URI MUST be an AtomPub Service Document (as specified in [RFC5023]) and follow the OData conventions for AtomPub Service Documents (or an alternate representation of an Atom Service Document if a different format is requested). OData: JSON Format specifies such an alternate JSON-based representation of a service document. The service document is required to be returned from the root of an OData service to provide clients with a simple mechanism to enumerate all of the collections of resources available for the data service.</p>
 <div>
 <table border="1" cellspacing="0" cellpadding="0">
@@ -42,10 +42,10 @@ _______________________________________/ __________________/  _________________/
 </tbody>
 </table>
 </div>
-<h2 role="heading">3. Resource Path</h2>
+<h2>3. Resource Path</h2>
 <p>The resource path construction rules defined in this section are optional. OData servers are encouraged to follow the URI path construction rules (in addition to the required query string rules) as such consistency promotes a rich ecosystem of reusable client components and libraries.</p>
 <p>The resource path section of a URI identifies the resource to be interacted with (such as Customers, a single Customer, Orders related to Customers in London, and so forth). The resource path enables any aspect of the data model (Collections of Entries, a single Entry, Properties, Links, Service Operations, and so on) exposed by an OData service to be addressed.</p>
-<h3 role="heading">3.1. Addressing Entries</h3>
+<h3>3.1. Addressing Entries</h3>
 <hr />
 <p>The basic rules for addressing a Collection (of Entries), a single Entry within a Collection, as well as a property of an Entry are illustrated in the figure below.</p>
 <p><a href="/assets/ResourcePath.png" rel="attachment wp-att-9621"><img class="wp-image-9621" alt="ResourcePath" src="/assets/ResourcePath.png" width="1154" height="101" /></a></p>
@@ -97,7 +97,7 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>Same as the URI above, but identifies the "raw value" of the City property.</li>
 </ul>
-<h3 role="heading"> 3.2. Addressing Links between Entries</h3>
+<h3> 3.2. Addressing Links between Entries</h3>
 <hr />
 <p>Much like the use of links on Web pages, the data model used by OData services supports relationships as a first class construct. For example, an OData service could expose a Collection of Products Entries each of which are related to a Category Entry.</p>
 <p>Associations between Entries are addressable in OData just like Entries themselves are (as described above). The basic rules for addressing relationships are shown in the following figure.</p>
@@ -117,7 +117,7 @@ _______________________________________/ __________________/  _________________/
 <li>Identifies the Category related to Product 1.</li>
 <li>Is described by the Navigation Property named "Category" on the "Product" Entity Type in the associated service metadata document.</li>
 </ul>
-<h3 role="heading"> 3.3. Addressing Service Operations</h3>
+<h3> 3.3. Addressing Service Operations</h3>
 <hr />
 <p>OData services can expose Service Operations which, like Entries, are identified using a URI. Service Operations are simple functions exposed by an OData service whose semantics are defined by the author of the function. A Service Operation can accept primitive type input parameters and can be defined to return a single primitive, single complex type, collection of primitives, collection of complex types, a single Entry, a Collection of Entries, or void. The basic rules for constructing URIs to address Service Operations and to pass parameters to them are illustrated in the following figure.</p>
 <p><a href="/assets/addressingServiceOperations.png" rel="attachment wp-att-9871"><img class="wp-image-9871" alt="addressingServiceOperations" src="/assets/addressingServiceOperations.png" width="644" height="48" /></a></p>
@@ -154,13 +154,13 @@ _______________________________________/ __________________/  _________________/
 <li>Identifies the ProductColors Service Operation that accepts no parameters.</li>
 <li>Is described by the Function Import named "ProductColors" in the service metadata document. This function returns a collection of strings.</li>
 </ul>
-<h2 role="heading">4. Query String Options</h2>
+<h2>4. Query String Options</h2>
 <p>The Query Options section of an OData URI specifies three types of information: <a href="../uri-conventions#SystemQueryOptions">System Query Options</a>, <a href="../uri-conventions#CustomerQueryOptions"> Custom Query Options</a>, and <a href="../uri-conventions#ServiceOperationParameters">Service Operation Parameters</a>. All OData services must follow the query string parsing and construction rules defined in this section and its subsections.</p>
-<h3 role="heading">4.1. System Query Options</h3>
+<h3>4.1. System Query Options</h3>
 <hr />
 <p>System Query Options are query string parameters a client may specify to control the amount and order of the data that an OData service returns for the resource identified by the URI. The names of all System Query Options are prefixed with a "$" character.</p>
 <p>An OData service may support some or all of the System Query Options defined. If a data service does not support a System Query Option, it must reject any requests which contain the unsupported option as defined by the request processing rules in <a href="../operations">[OData:Operations]</a>.</p>
-<h3 role="heading"> 4.2. Orderby System Query Option ($orderby)</h3>
+<h3> 4.2. Orderby System Query Option ($orderby)</h3>
 <hr />
 <p>A data service URI with a $orderby System Query Option specifies an expression for determining what values are used to order the collection of Entries identified by the Resource Path section of the URI. This query option is only supported when the resource path identifies a Collection of Entries.</p>
 <p>The $orderby section of the normative OData specification outlines the full expression syntax supported by this query option. The examples below represent the most commonly supported subset of that expression syntax.</p>
@@ -177,7 +177,7 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>Same as the URI above except the set of Products is subsequently sorted (in descending order) by the Name property of the related Category Entry.</li>
 </ul>
-<h3 role="heading">4.3. Top System Query Option ($top)</h3>
+<h3>4.3. Top System Query Option ($top)</h3>
 <hr />
 <p>A data service URI with a $top System Query Option identifies a subset of the Entries in the Collection of Entries identified by the Resource Path section of the URI. This subset is formed by selecting only the first N items of the set, where N is an integer greater than or equal to zero specified by this query option. If a value less than zero is specified, the URI should be considered malformed.</p>
 <p>If the data service URI contains a $top query option, but does not contain a $orderby option, then the Entries in the set needs to first be fully ordered by the data service. While no ordering semantics are mandated, to ensure repeatable results, a data service must always use the same semantics to obtain a full ordering across requests.</p>
@@ -190,7 +190,7 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>The first 5 Product Entries returned in descending order when sorted by the Name property.</li>
 </ul>
-<h3 role="heading"> 4.4. Skip System Query Option ($skip)</h3>
+<h3> 4.4. Skip System Query Option ($skip)</h3>
 <hr />
 <p>A data service URI with a $skip System Query Option identifies a subset of the Entries in the Collection of Entries identified by the Resource Path section of the URI. That subset is defined by seeking N Entries into the Collection and selecting only the remaining Entries (starting with Entry N+1). N is an integer greater than or equal to zero specified by this query option. If a value less than zero is specified, the URI should be considered malformed.</p>
 <p>If the data service URI contains a $skip query option, but does not contain a $orderby option, then the Entries in the Collection must first be fully ordered by the data service. While no ordering semantics are mandated, to ensure repeatable results a data service must always use the same semantics to obtain a full ordering across requests.</p>
@@ -203,7 +203,7 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>The third and fourth Product Entry from the collection of all products when the collection is sorted by Rating (ascending).</li>
 </ul>
-<h3 role="heading"> 4.5. Filter System Query Option ($filter)</h3>
+<h3> 4.5. Filter System Query Option ($filter)</h3>
 <hr />
 <p>A URI with a $filter System Query Option identifies a subset of the Entries from the Collection of Entries identified by the <a href="../uri-conventions#ResourcePath">Resource Path</a> section of the URI. The subset is determined by selecting only the Entries that satisfy the predicate expression specified by the query option.</p>
 <p>The expression language that is used in $filter operators supports references to properties and literals. The literal values can be strings enclosed in single quotes, numbers and boolean values (true or false) or any of the additional literal representations shown in the <a href="../overview#AbstractDataModel">Abstract Type System</a> section.</p>
@@ -431,7 +431,7 @@ _______________________________________/ __________________/  _________________/
 </tbody>
 </table>
 </div>
-<h3 role="heading"> 4.6. Expand System Query Option ($expand)</h3>
+<h3> 4.6. Expand System Query Option ($expand)</h3>
 <hr />
 <p>A URI with a $expand System Query Option indicates that Entries associated with the Entry or Collection of Entries identified by the Resource Path section of the URI must be represented inline (i.e. eagerly loaded). For example, if you want to identify a category and its products, you could use two URIs (and execute two requests), one for /Categories(1) and one for /Categories(1)/Products. The '$expand' option allows you to identify related Entries with a single URI such that a graph of Entries could be retrieved with a single HTTP request.</p>
 <p>The syntax of a $expand query option is a comma-separated list of Navigation Properties. Additionally each Navigation Property can be followed by a forward slash and another Navigation Property to enable identifying a multi-level relationship.</p>
@@ -452,7 +452,7 @@ _______________________________________/ __________________/  _________________/
 <li>Identifies the set of Products as well as the category and suppliers associated with each product.</li>
 <li>Is described by the Entity Set named "Products" as well as the "Category" and "Suppliers" Navigation Property on the "Product" Entity Type in the service metadata document.</li>
 </ul>
-<h3 role="heading"> 4.7. Format System Query Option ($format)</h3>
+<h3> 4.7. Format System Query Option ($format)</h3>
 <hr />
 <p>A URI with a $format System Query Option specifies that a response to the request MUST use the media type specified by the query option. If the $format query option is present in a request URI it takes precedence over the value(s) specified in the Accept request header. Valid values for the $format query string option are listed in the following table.</p>
 <div>
@@ -494,7 +494,7 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>Identifies all Product Entries represented using the JSON format as defined in <a href="../json-format">[OData:JSON]</a></li>
 </ul>
-<h3 role="heading"> 4.8. Select System Query Option ($select)</h3>
+<h3> 4.8. Select System Query Option ($select)</h3>
 <hr />
 <p>A data service URI with a $select System Query Option identifies the same set of Entries as a URI without a $select query option; however, the value of $select specifies that a response from an OData service should return a subset of the Properties which would have been returned had the URI not included a $select query option.</p>
 <p>Version Note: This query option is only supported in OData version 2.0 and above.</p>
@@ -523,7 +523,7 @@ _______________________________________/ __________________/  _________________/
 <li>In a response from an OData service, the Name property is included and Product Entries with all Properties are included; however, rather than including the fully expanded Supplier Entries referenced in the expand clause, each Product will contain a link that references the corresponding Collection of Supplier Entries.</li>
 </ul>
 <p>Note: The $select section of the <a href="https://www.odata.org/media/6655/[mc-apdsu][1].htm">normative OData specification</a> provides an ABNF grammar for the expression language supported by this query option.</p>
-<h3 role="heading"> 4.9. Inlinecount System Query Option ($inlinecount)</h3>
+<h3> 4.9. Inlinecount System Query Option ($inlinecount)</h3>
 <hr />
 <p>A URI with a $inlinecount System Query Option specifies that the response to the request includes a count of the number of Entries in the Collection of Entries identified by the <a href="../uri-conventions#ResourcePath">Resource Path</a> section of the URI. The count must be calculated after applying any <a href="../uri-conventions#FilterSystemQueryOption">$filter System Query Options</a> present in the URI. The set of valid values for the $inlinecount query option are shown in the table below. If a value other than one shown in Table 4 is specified the URI is considered malformed.</p>
 <p>Version Note: This query option is only supported in OData version 2.0 and above</p>
@@ -554,19 +554,19 @@ _______________________________________/ __________________/  _________________/
 <ul>
 <li>Identifies the first 10 Product Entries that cost more than 200 and includes a count of the total number of Product Entries that cost more than 200.</li>
 </ul>
-<h2 role="heading">5. Custom Query Options</h2>
+<h2>5. Custom Query Options</h2>
 <p>Custom Query Options provide an extension point for OData service-specific information to be placed in the query string portion of a URI. A Custom Query String option is defined as any name/value pair query string parameter where the name of the parameter does not begin with the "$" character. Any URI exposed by an OData service may include one or more Custom Query Options.</p>
 <p>Examples</p>
 <p><a href="https://services.odata.org/OData/OData.svc/Products?x=y">https://services.odata.org/OData/OData.svc/Products?x=y</a></p>
 <ul>
 <li>Identifies all Product entities. Includes a Custom Query Option "x" whose meaning is service specific.</li>
 </ul>
-<h2 role="heading"> 6. Service Operation Parameters</h2>
+<h2> 6. Service Operation Parameters</h2>
 <p>Service Operations represent functions exposed by an OData service. These functions may accept zero or more primitive type parameters. If a Service Operation requires an input parameter those parameters are passed via query string name/value pairs appended to the URI which identify the Service Operation as described in the <a href="../uri-conventions#AddressingServiceOperations"> Addressing Service Operations</a> section. For nullable type parameters, a null value may be specified by not including the parameter in the query string of the URI.</p>
 <p>Examples</p>
 <p><a href="https://services.odata.org/OData/OData.svc/GetProductsByRating?rating=5">https://services.odata.org/OData/OData.svc/GetProductsByRating?rating=5</a></p>
 <ul>
 <li>Identifies the "GetProductsByRating" Service Operation and specifies a value of 5 for the "rating" input parameter.</li>
 </ul>
-<h2 role="heading">7. URI Equivalence</h2>
+<h2>7. URI Equivalence</h2>
 <p>When determining if two URIs are equivalent, each URI SHOULD be normalized using the rules specified in <a href="http://tools.ietf.org/html/rfc3987">[RFC3987]</a> and <a href="http://tools.ietf.org/html/rfc3986">[RFC3986]</a> and then compared for equality using the equivalence rules specified in <a href="http://tools.ietf.org/html/rfc2616#section-3.2.3"> HTTP [RFC 2616], Section 3.2.3</a>.</p>


### PR DESCRIPTION
Description:
Basically Im removing the  role="heading" tag from the below pages so that the narrator can use the preferred <hx> tag. With the  role="heading" tag, the reader reads all heading levels as heading, when removed, it reads them appropriately as H1, H2 etc.

see work item
https://dev.azure.com/IdentityDivision/Engineering/_queries/query/63f49107-d74b-44c1-a570-c3fdaa2758f0/
Environment Details: 
#URL:https://www.odata.org/​

Browser Details: 
Microsoft Edge 44.18362.449.0​

​OS Details:​
Microsoft windows 10 enterprise ​
Version: 1909 Build 18363.592​
​
Note:​
The same issue is present in the below pages​
1.URI Conventions(OData Version 2.0) ​
2.Operations(OData Version 2.0 )​
3.Batch Processing (OData Version 2.0)​
4.Atom Format(OData Version 2.0)​
5.JSON Format(OData Version 2.0)​
​
NVDA behaviour:​
NVDA is reading properly, it is not announcing all headings as heading level 1.​
​
Repro Steps: ​​​
1)Start Narrator​
2)Hit the URL "https://www.odata.org/" and login with appropriate credentials to open Odata website​
3)Tab till 'Developers' link and press enter​
4)Tab till 'Documentation' option and press enter​
5)Tab till "OData version 3.0" link and press enter​
6)Tab till "OData Version 3.0 JSON Verbose Format" link and press enter​
7)Verify All headings present in the page narrator is announcing as heading level 1 or not​
​
Actual Result: ​​​
All headings present in the page Narrator is announcing incorrectly as heading level 1​
​
Expected Result:​
All headings present in the page Narrator shouldn't announce as heading level 1​
​
User Impact: ​​
Screen reader users will get confused if Narrator is announcing all headings as heading level 1 ​
​
MAS Reference: ​​​
https://microsoft.sharepoint.com/:w:/r/teams/msenable/_layouts/15/WopiFrame.aspx?sourcedoc={54f28d1f-a2d1-4dcd-84e1-5c9b87e8aba4}