### PR TITLE
Fix tab narrations on Developers-Libraries page

### DIFF
--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -5,21 +5,21 @@ date: 2014-02-20 06:57:09.000000000 +08:00
 permalink: /libraries/
 ---
 <div role="tablist" aria-label="Languages">
-<ul class="nav nav-pills" id="tablinks">
+<ul role="presentation" class="nav nav-pills" id="tablinks">
   <li role="presentation" class="active">
-    <a href="#net1" role="tab" aria-label=".net" data-toggle="pill" aria-controls="net1">.NET</a>
+    <a role="tab" href="#net1" aria-label=".net" data-toggle="pill" aria-controls="net1">.NET</a>
   </li>
   <li role="presentation">
-    <a href="#java" role="tab" aria-label="Java" data-toggle="pill" aria-controls="java" tabindex="-1">Java</a>
+    <a role="tab" href="#java" aria-label="Java" data-toggle="pill" aria-controls="java" tabindex="-1">Java</a>
   </li>
   <li role="presentation">
-    <a href="#javascript" role="tab" aria-label="JavaScript" data-toggle="pill" aria-controls="javascript" tabindex="-1">JavaScript</a>
+    <a role="tab" href="#javascript" aria-label="JavaScript" data-toggle="pill" aria-controls="javascript" tabindex="-1">JavaScript</a>
   </li>
   <li role="presentation">
-    <a href="#cpp" role="tab"  aria-label="C++" data-toggle="pill" aria-controls="cpp" tabindex="-1">C++</a>
+    <a role="tab" href="#cpp"  aria-label="C++" data-toggle="pill" aria-controls="cpp" tabindex="-1">C++</a>
   </li>
   <li role="presentation">
-    <a href="#other" role="tab" aria-label="Other Platforms" data-toggle="pill" aria-controls="other" tabindex="-1">Other Platforms</a>
+    <a role="tab" href="#other" aria-label="Other Platforms" data-toggle="pill" aria-controls="other" tabindex="-1">Other Platforms</a>
   </li>
 </ul>
 </div>


### PR DESCRIPTION
Fix tab narrations on Developers-Libraries page

Have the tabs read as follows:
.NET tab 1 of 5
Java tab 2 of 5
JavaScript tab 3 of 5
C++ tab 4 of 5
Other Platforms tab 5 of 5