### PR TITLE
fix focus lost after close button on pop up

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1355,10 +1355,10 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <script>
     $(document).ready(function() {
        $('.modal').on('shown.bs.modal', function () {
-            $('.btn-default').focus();
+            $('.close').focus();
+            trapFocus(this)
             $(this).find(".modal-body").attr("tabindex", 0);
        });
-
         // make it possible to tab to response content inside popups for keyboard users
         $(".modal-body pre").attr("tabindex", 0);
         $(".modal-body").attr("aria-label", "Response body");
@@ -1380,4 +1380,37 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             modalBody.insertBefore(screenReaderContent, modalBody.firstChild);
         });
     });
+
+    function trapFocus(element) {
+        var focusableElements = element.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])'),
+        firstFocusableElement = focusableElements[0];  
+        lastFocusableElement = focusableElements[focusableElements.length - 1];
+        KEYCODE_TAB = 9;
+
+        element.addEventListener('keydown', function(e) {
+            var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+            if (!isTabPressed) { 
+                return; 
+            }
+
+            if ( e.shiftKey )
+            {
+                if (document.activeElement === firstFocusableElement) 
+                {
+                    lastFocusableElement.focus();
+                        e.preventDefault();
+                    }
+                } 
+                else
+                {
+                    if (document.activeElement === lastFocusableElement) 
+                    {
+                        firstFocusableElement.focus();
+                        e.preventDefault();
+                    }
+                }
+
+            });
+        }
 </script>

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1383,22 +1383,24 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 
     function trapFocus(element) {
         var focusableElements = element.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled])'),
-        firstFocusableElement = focusableElements[0];  
-        lastFocusableElement = focusableElements[focusableElements.length - 1];
-        KEYCODE_TAB = 9;
+        if(focusableElements.length != 0)
+        {
+            firstFocusableElement = focusableElements[0];  
+            lastFocusableElement = focusableElements[focusableElements.length - 1];
+            KEYCODE_TAB = 9;
 
-        element.addEventListener('keydown', function(e) {
-            var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+            element.addEventListener('keydown', function(e) {
+                var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
 
-            if (!isTabPressed) { 
-                return; 
-            }
+                if (!isTabPressed) { 
+                    return; 
+                }
 
-            if ( e.shiftKey )
-            {
-                if (document.activeElement === firstFocusableElement) 
+                if ( e.shiftKey )
                 {
-                    lastFocusableElement.focus();
+                    if (document.activeElement === firstFocusableElement) 
+                    {
+                        lastFocusableElement.focus();
                         e.preventDefault();
                     }
                 } 
@@ -1413,4 +1415,5 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 
             });
         }
+    }
 </script>


### PR DESCRIPTION
Check out Accessibility Insights! - Identify accessibility bugs before check-in and make bug fixing faster and easier.

Environment Details: 
#URL:https://www.odata.org/​

Browser Details: 
Microsoft Edge 44.18362.449.0​
Chrome Version 79.0.3945.130 (Official Build) (64-bit)​
​
OS Details:​
Microsoft windows 10 enterprise ​
Version: 1909 Build 18363.592​
​
Repro Steps: ​​​
1)Hit the URL "https://www.odata.org/" to open Odata website​
2)Tab till 'Developers' link and press enter​
3)Tab till 'Getting Started' option and press enter​
4)Tab till 'Understand OData in 6 steps' link and press enter​
5)Tab till 'View the response' button and press enter​
6)Verify Focus is visible on any control or not after the 'Close' button in 'Response' popup​
​
​Actual Result: ​​​
Focus is not visible on any control(focus is lost) after the 'Close' button and one extra keyboard stroke is taking to reach to the close button symbol present in the top of the popup
​
Expected Result:​
Focus should be visible on next control (close button symbol )with in the popup, focus shouldn't be lost after the 'Close' button​.
​
User Impact: ​​
Keyboard only users will face difficulty while using the application if the Focus is not visible on any control(focus is lost)​
​