### PR TITLE
Fix accessibility issues on multiple tables

### DIFF
--- a/pages/documentation/atom-format-v3.html
+++ b/pages/documentation/atom-format-v3.html
@@ -50,7 +50,7 @@ permalink: /documentation/odata-version-3-0/atom-format/
 <h1 id="primitivetypesinatom">4. Primitive Types in Atom</h1>
 <p>OData Atom and XML payloads serialize primitive types as shown in the table below.</p>
 <p>For full syntax rules, see <a href="../abnf">OData:ABNF</a>:</p>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Primitive Types in Atom">
 <tbody>
 <tr>
 <th>Primitive Type</th>

--- a/pages/documentation/json-format-v2.html
+++ b/pages/documentation/json-format-v2.html
@@ -17,7 +17,7 @@ permalink: /documentation/odata-version-2-0/json-format/
 <p>The following sections define how resources exposed by an OData service can be represented in requests and/or responses payloads using the JSON format. For details regarding how to create various request types (Retrieve, Create, etc) see <a href="../operations">[OData-Operations]</a> . <strong>Security Note</strong>: In responses payloads (not request payloads) all the JSON representations described in this section are wrapped by an outer most object that includes a single name/value pair. The name of the name/value pair is always "d" and the value is the JSON representation of an OData resource as described by the subsections of this document. This pattern ensures JSON payloads returned from OData services are valid JSON statements, but not valid JavaScript statements. This prevents an OData JSON response from being executed as the result of a cross site scripting (XSS) attack.</p>
 <h2>4. Primitive Types</h2>
 <p>Values of an OData primitive type are represented as JSON literal values as per the table below. Note: The type system used by OData services is described in full in the <a href="../overview#AbstractTypeSystem">Abstract Type System</a> section of the <a href="../overview">[OData-Core]</a> document.</p>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Primitive Types Representation">
 <tbody>
 <tr>
 <th valign="bottom" width="148">Primitive Type</th>
@@ -129,7 +129,7 @@ OData V2: {
 }{% endhighlight %}
 <h2>7. Representing Entries</h2>
 <p>In OData v1, Entries are represented as JSON objects with all the <a href="../terminology">properties</a> of the Entry represented as name/value pairs of the object. Alternatively, if the Entry is being represented was identified with a URI that includes a Select System Query Option, then the prior rule is relaxed such that only the properties identified by the $select query option are represented as name/value pairs. OData v2 represents Entries the same way as V1. An optional "__metadata" name/value pair is the only pair that should be included on the object that does not directly represent a Property of the Entry being represented. This name/value pair is not data, but instead, by convention defined in this document, specifies the metadata for the Entry being represented. The value of the "__metadata" name/value pair is a JSON object that contains the name/value pairs described in the table below.</p>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Entries Representation">
 <tbody>
 <tr>
 <th valign="top" width="136"><strong>"__metadata" object name/value pairs</strong></th>
@@ -230,7 +230,7 @@ OData V2: {
 } {% endhighlight %}
 <h2>10. Representing Media Link Entries</h2>
 <p><a href="../terminology">Media Link Entries (MLE)</a> are represented in the same way as "plain" Entries as described in <a href="../json-format#RepresentingEntries"> Representing Entries</a>; however, they also contain additional metadata per Entry that describes the Media Resource (MR) associated with the Entry. This additional MR metadata is represented as name/value pairs of the "__metadata" object associated with the Entry.</p>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Media Link Entries Representation">
 <tbody>
 <tr>
 <th valign="top" width="136"><strong>"__metadata" object name/value pairs for MLEs</strong></th>

--- a/pages/documentation/odata-version-3-0-core-protocol.html
+++ b/pages/documentation/odata-version-3-0-core-protocol.html
@@ -264,8 +264,7 @@ permalink: /documentation/odata-version-3-0/odata-version-3-0-core-protocol/
 <p>The value of the <code>$filter</code> option is a boolean expression as defined in <a href="https://www.odata.org/documentation/odata-version-3-0/abnf">OData:ABNF</a>.</p>
 <h5 id="built-infilteroperations">10.2.3.1.1. Built-in Filter Operations</h5>
 <p>OData supports a set of built-in filter operations, as described in this section. For a full description of the syntax used when building requests, see <a href="https://www.odata.org/documentation/odata-version-3-0/url-conventions">OData:URL</a>.</p>
-<p>l</p>
-<table border="1">
+<table border="1" aria-label="Filter Query Option Operators">
 <tbody>
 <tr>
 <th>Operator</th>
@@ -361,7 +360,7 @@ permalink: /documentation/odata-version-3-0/odata-version-3-0-core-protocol/
 <h5 id="built-inqueryfunctions">10.2.3.1.2. Built-in Query Functions</h5>
 <p>OData supports a set of built-in functions that can be used within <code>$filter</code> operations. The following table lists the available functions. For a full description of the syntax used when building requests, see <a href="https://www.odata.org/documentation/odata-version-3-0/url-conventions">OData:URL</a>.</p>
 <p>OData does note define an ISNULL or COALESCE operator. Instead, there is a <code>null</code> literal which can be used in comparisons.</p>
-<table border="1">
+<table border="1" aria-label="Functions for use with Filter Query Option">
 <tbody>
 <tr>
 <th>Function</th>

--- a/pages/documentation/overview.html
+++ b/pages/documentation/overview.html
@@ -10,7 +10,7 @@ permalink: /documentation/odata-version-2-0/overview/
 <p>The Open Data Protocol (OData) enables the creation of HTTP-based data services, which allow resources identified using Uniform Resource Identifiers (URIs) and defined in an abstract data model, to be published and edited by Web clients using simple HTTP messages. OData is intended to be used to expose and access information from a variety of sources including, but not limited to, relational databases, file systems, content management systems, and traditional Web sites.</p>
 <p>OData is made up of a group of specifications. This specification describes OData's core concepts and the following specifications define optional extensions to the foundations defined in this document:</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="OData Specifications">
 <tbody>
 <tr>
 <th>Specification</th>
@@ -73,7 +73,7 @@ permalink: /documentation/odata-version-2-0/overview/
 <p>Putting the above paragraphs into OData terms, the feeds exposed by an OData service are represented by <strong>Entity Sets</strong> or a Navigation Property on an Entity Type that identifies a collection of entities. For example, the Entity Set identified by the URI https://services.odata.org/OData/OData.svc/Products or the collection of entities identified by the "Products" navigation property in https://services.odata.org/OData/OData.svc/Categories(1)/Products identifies a feed of entries exposed by the OData service.</p>
 <p>Each Entry of an OData feed is described in the EDM by an <strong>Entity Type</strong> and each link between entries are described by a <strong>Navigation Property</strong>. OData resources are described in the table below.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="OData Resources">
 <tbody>
 <tr>
 <th>OData Resource</th>
@@ -137,7 +137,7 @@ permalink: /documentation/odata-version-2-0/overview/
 <p>An example Service Metadata Document that describes three Entity Types (Categories, Products and Suppliers), the relationships among them and one "ProductsByRating" Service Operation is accessible at <a href="https://services.odata.org/OData/OData.svc/$metadata"> https://services.odata.org/OData/OData.svc/$metadata</a> .</p>
 <p>CSDL annotations are used to describe OData specific extensions to CSDL. Those annotations (represented as attributes in the <a href="../terminology#ODataMetadataNS"> OData metadata namespace</a>) are described in the table below. Note: additional Atom format specific CSDL annotations are defined in <a title="Atom Format" href="../atom-format">[OData: Atom]</a>.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="CSDL Annotations">
 <tbody>
 <tr>
 <th>Annotation</th>
@@ -168,7 +168,7 @@ permalink: /documentation/odata-version-2-0/overview/
 </div>
 <h2>6. Primitive Data Types</h2>
 <p>The Abstract Type System used to define the primitive types supported by OData is defined in detail in [MC-CSDL] (section 2.2.1). Table 2 summaries the set of primitive types supported as well as how each MUST be represented when used in an OData URI or HTTP header. Primitive type representations in request and response payloads are defined in the <a title="Atom Format" href="../atom-format"> [OData:Atom]</a> and <a title="JSON Format" href="../json-format"> [OData:JSON]</a> specifications.</p>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Primitive Data Types">
 <tbody>
 <tr>
 <th>Primitive Types</th>

--- a/pages/documentation/terminology.html
+++ b/pages/documentation/terminology.html
@@ -7,9 +7,9 @@ permalink: /documentation/odata-version-2-0/terminology/
 <h5 class="alert alert-success">OData Version 4.0 is the current recommended version of OData. OData V4 has been standardized by OASIS and has many features not included in OData Version 2.0. 
 <br><br>
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></h5>
-<h2 id="SummaryOfRefs" role="heading">Summary of References:</h2>
+<h2 role="heading">Summary of References:</h2>
 <div>
-<table border="1" cellspacing="0" cellpadding="0" aria-labelledby="SummaryOfRefs">
+<table border="1" cellspacing="0" cellpadding="0" role="presentation" aria-label="Summary of References">
 <tbody>
 <tr>
 <th valign="top" width="151">Reference</th>

--- a/pages/documentation/uri-conventions.html
+++ b/pages/documentation/uri-conventions.html
@@ -25,7 +25,7 @@ _______________________________________/ __________________/  _________________/
 <h2>2. Service Root URI</h2>
 <p>The service root URI identifies the root of an OData service. The resource identified by this URI MUST be an AtomPub Service Document (as specified in [RFC5023]) and follow the OData conventions for AtomPub Service Documents (or an alternate representation of an Atom Service Document if a different format is requested). OData: JSON Format specifies such an alternate JSON-based representation of a service document. The service document is required to be returned from the root of an OData service to provide clients with a simple mechanism to enumerate all of the collections of resources available for the data service.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Service Root URIs Examples">
 <tbody>
 <tr>
 <th>Example Request URI</th>
@@ -210,7 +210,7 @@ _______________________________________/ __________________/  _________________/
 <p>Note: The $filter section of the normative OData specification provides an ABNF grammar for the expression language supported by this query option.</p>
 <p>The operators supported in the expression language are shown in the following table.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Filter Query Option Operators">
 <tbody>
 <tr>
 <th>Operator</th>
@@ -306,7 +306,7 @@ _______________________________________/ __________________/  _________________/
 </div>
 <p>In addition to operators, a set of functions are also defined for use with the filter query string operator. The following table lists the available functions. Note: ISNULL or COALESCE operators are not defined. Instead, there is a null literal which can be used in comparisons.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Functions for use with Filter Query Option">
 <tbody>
 <tr>
 <th valign="top">Function</th>
@@ -456,7 +456,7 @@ _______________________________________/ __________________/  _________________/
 <hr />
 <p>A URI with a $format System Query Option specifies that a response to the request MUST use the media type specified by the query option. If the $format query option is present in a request URI it takes precedence over the value(s) specified in the Accept request header. Valid values for the $format query string option are listed in the following table.</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Valid values for Format Query Option">
 <tbody>
 <tr>
 <th>$format Value</th>
@@ -528,7 +528,7 @@ _______________________________________/ __________________/  _________________/
 <p>A URI with a $inlinecount System Query Option specifies that the response to the request includes a count of the number of Entries in the Collection of Entries identified by the <a href="../uri-conventions#ResourcePath">Resource Path</a> section of the URI. The count must be calculated after applying any <a href="../uri-conventions#FilterSystemQueryOption">$filter System Query Options</a> present in the URI. The set of valid values for the $inlinecount query option are shown in the table below. If a value other than one shown in Table 4 is specified the URI is considered malformed.</p>
 <p>Version Note: This query option is only supported in OData version 2.0 and above</p>
 <div>
-<table border="1" cellspacing="0" cellpadding="0">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Valid values for Inlinecount Query Option">
 <tbody>
 <tr>
 <th valign="top">$inlinecount value</th>

--- a/pages/ecosystem.html
+++ b/pages/ecosystem.html
@@ -17,11 +17,11 @@ permalink: /ecosystem/
 <div class="col-md-10">
 <div class="tab-content">
 	<div id="producers" class="tab-pane active">
-	<h2>Producers</h2>
+	<h2 id="producers_header">Producers</h2>
 	OData producers are services that expose their data using the OData protocol. Below we have collected a list of key OData producers, which will continue to grow along with the OData ecosystem. You can use <a href="https://www.odata.org/libraries">OData SDK</a> to build your own OData producers. If you create or know of an OData producer not listed be sure to let us know via our new <a href="https://www.odata.org/contribution">contribution page</a>.
 
 	<a href="http://www.telerik.com/products/orm.aspx">Telerik OpenAccess ORM</a>In mid-2010 Telerik released a LINQ implementation that is simple to use and produces domain models very fast. Built on top of the enterprise-grade Telerik OpenAccess ORM the LINQ implementation allows you to easily build an OData feed via a few easy steps by using the OpenAccess Visual Designer and the Data Services Wizard. For more info, visit <a href="https://www.telerik.com/odata">www.telerik.com/odata</a>
-	<table class="table table-striped table-hover">
+	<table class="table table-striped table-hover" role="presentation" aria-describedby="producers_header">
 	<tbody>
 		{% assign producers = site.ecosys | where: "category", "producers" %}
 		{% for producer in producers %}
@@ -40,9 +40,9 @@ permalink: /ecosystem/
 	</table>
 	</div>
 	<div id="consumers" class="tab-pane">
-	<h2>Consumers</h2>
+	<h2 id="consumers_header">Consumers</h2>
 	OData consumers are simply applications that consume data exposed using the OData protocol. OData consumers can vary greatly in sophistication, from something as simple as your web browser all the way through to a custom application that takes advantage of all the features of the OData Protocol. Below we have collected a list of key OData consumers, which will continue to grow along with the OData ecosystem. Simply pick a consumer from the list below and point it at one of the live services. If you create or know of an OData consumer not listed be sure to let us know via our new <a href="https://www.odata.org/contribution">contribution page</a>.
-	<table class="table table-striped table-condensed table-hover">
+	<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="consumers_header">
 	<tbody>
 		{% assign consumers = site.ecosys | where: "category", "consumers" %}
 		{% for consumer in consumers %}
@@ -61,8 +61,8 @@ permalink: /ecosystem/
 </table>
 </div>
 <div id="liveservices" class="tab-pane">
-Live Services
-<table class="table table-striped table-condensed table-hover">
+	<h2 id="liveservices_header">Live Services</h2>
+<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="liveservices_header">
 <tbody>
 	{% assign liveservices = site.ecosys | where: "category", "liveservices" %}
 	{% for liveservice in liveservices %}
@@ -81,9 +81,9 @@ Live Services
 </table>
 </div>
 <div id="sdk" class="tab-pane">
-<h2>OData SDK - Sample Code</h2>
+<h2 id="sdk_header">OData SDK - Sample Code</h2>
 The OData SDK includes some sample code to show you how to do everything from create a general purpose OData Explorer to creating OData services and tests that verify that service is producing valid OData.
-<table class="table table-striped table-condensed table-hover">
+<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="sdk_header">
 <tbody>
 	{% assign sdks = site.ecosys | where: "category", "sdk" %}
 	{% for sdk in sdks %}
@@ -107,8 +107,8 @@ The OData SDK includes some sample code to show you how to do everything from cr
 </table>
 </div>
 <div id="tutorials" class="tab-pane">
-<h2>Tutorials</h2>
-<table class="table table-striped table-condensed table-hover">
+<h2 id="tutorials_header">Tutorials</h2>
+<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="tutorials_header">
 <tbody>
 	{% assign tutorials = site.ecosys | where: "category", "tutorials" %}
 	{% for tutorial in tutorials %}

--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -27,7 +27,7 @@ permalink: /libraries/
 <p></p>
 <div class="tab-content">
   <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
-    <table class="table table-striped table-condensed table-hover" style="width:100%">
+    <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label=".NET Libraries">
       <tr>
         <th width="20%">Name</th>
         <th width="50%">Description</th>
@@ -61,7 +61,7 @@ permalink: /libraries/
   {% for library in libraries %}
 
   <div class="tab-pane {% if forloop.first == true %}hide{% endif%}" id="{{library.name}}" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover" style="width:100%">
+    <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label="{{library.name}} Libraries">
       <tr>
         <th width="20%">Name</th>
         <th width="50%">Description</th>

--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -19,7 +19,7 @@ permalink: /odata-services/
 
 <div class="tab-content">
   <div id="odata-v4" tabindex="0" class="tab-pane active" role="tabpanel">
-    <table class="table table-striped table-condensed table-hover">
+    <table class="table table-striped table-condensed table-hover" role="presentation" aria-label="OData v4 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>
@@ -60,7 +60,7 @@ permalink: /odata-services/
     </table>
   </div>
   <div class="tab-pane" id="v3" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover">
+    <table class="table table-striped table-condensed table-hover" role="presentation" aria-label="OData v3 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>
@@ -80,7 +80,7 @@ permalink: /odata-services/
     </table>
   </div>
   <div class="tab-pane" id="v2" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover">
+    <table class="table table-striped table-condensed table-hover" role="presentation" aria-label="OData v2 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>
@@ -102,8 +102,7 @@ permalink: /odata-services/
 </div>
 </div>
 
-  <div class="" id="service-usages">
-      {% capture my-include %}{% include_relative service-usages/basic-usages.md %}{% endcapture %}
-      {{ my-include | markdownify }}
-  </div>
+<div class="" id="service-usages">
+    {% capture my-include %}{% include_relative service-usages/basic-usages.md %}{% endcapture %}
+    {{ my-include | markdownify }}
 </div>


### PR DESCRIPTION
Fix accessibility issues affecting tables on the following pages by applying a name/label that a screen reader can read when navigating

OData Version 3.0 Core Protocol: https://www.odata.org/documentation/odata-version-3-0/odata-version-3-0-core-protocol/
Atom Format (OData Version 3.0): https://www.odata.org/documentation/odata-version-3-0/atom-format/
Overview (OData Version 2.0): https://www.odata.org/documentation/odata-version-2-0/overview/
Terminology (OData Version 2.0): https://www.odata.org/documentation/odata-version-2-0/terminology/
URI Conventions (OData Version 2.0): https://www.odata.org/documentation/odata-version-2-0/uri-conventions/
JSON Format (OData Version 2.0): https://www.odata.org/documentation/odata-version-2-0/json-format/
Libraries: https://www.odata.org/libraries/
Reference Services: https://www.odata.org/odata-services/