### PR TITLE
Fix tab navigation that was broken

### DIFF
--- a/public/tabs.js
+++ b/public/tabs.js
@@ -11,7 +11,7 @@
   generateArrays();
 
   function generateArrays () {
-    tabs = document.querySelectorAll('[role="tab"]');
+    tabs = document.querySelectorAll('[data-toggle="tab"]');
     panels = document.querySelectorAll('[role="tabpanel"]');
   };
 


### PR DESCRIPTION
These PRs broke the navigation across tabs when the 'role="tab"' attribute was removed and so it was impossible to use the arrow keys to move across the data tabs.
https://github.com/OData/odataorg.github.io/pull/238/files
https://github.com/OData/odataorg.github.io/pull/225/files

 I've updated the javascript code that was handling the navigation to check for 'data-toggle="tab"' instead.