### PR TITLE
Revert navigation links to tabs

### DIFF
--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -4,88 +4,89 @@ title: Libraries
 date: 2014-02-20 06:57:09.000000000 +08:00
 permalink: /libraries/
 ---
-<div role="tablist" aria-label="Languages">
-<ul role="presentation" class="nav nav-pills" id="tablinks">
-  <li role="presentation" class="active">
-    <a href="#net1" aria-label=".net" data-toggle="tab" aria-controls="net1">.NET</a>
-  </li>
-  <li role="presentation">
-    <a href="#java" aria-label="Java" data-toggle="tab" aria-controls="java" tabindex="-1">Java</a>
-  </li>
-  <li role="presentation">
-    <a href="#javascript" aria-label="JavaScript" data-toggle="tab" aria-controls="javascript" tabindex="-1">JavaScript</a>
-  </li>
-  <li role="presentation">
-    <a href="#cpp"  aria-label="C++" data-toggle="tab" aria-controls="cpp" tabindex="-1">C++</a>
-  </li>
-  <li role="presentation">
-    <a href="#other" aria-label="Other Platforms" data-toggle="tab" aria-controls="other" tabindex="-1">Other Platforms</a>
-  </li>
-</ul>
-</div>
+<div aria-label="Languages" id="tabs">
+  <ul role="tablist" class="nav nav-tabs" id="tablinks">
+    <li role="presentation" class="active">
+      <a href="#net1" aria-label=".net" role="tab" data-toggle="tab" aria-controls="net1">.NET</a>
+    </li>
+    <li role="presentation">
+      <a href="#java" aria-label="Java" role="tab" data-toggle="tab" aria-controls="java" tabindex="-1">Java</a>
+    </li>
+    <li role="presentation">
+      <a href="#javascript" aria-label="JavaScript" role="tab" data-toggle="tab" aria-controls="javascript" tabindex="-1">JavaScript</a>
+    </li>
+    <li role="presentation">
+      <a href="#cpp" aria-label="C++" role="tab" data-toggle="tab" aria-controls="cpp" tabindex="-1">C++</a>
+    </li>
+    <li role="presentation">
+      <a href="#other" aria-label="Other Platforms" role="tab" data-toggle="tab" aria-controls="other" tabindex="-1">Other Platforms</a>
+    </li>
+  </ul>
+  <div class="tab-content">
+    <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
+      <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label=".NET Libraries">
+        <tr>
+          <th width="20%">Name</th>
+          <th width="50%">Description</th>
+          <th width="10%">Support OData version(s)</th>
+          <th width="10%">For server/client</th>
+          <th width="10%">Download from</th>
+        </tr>
+        {% assign nets = site.libraries | where: "category", "net" | sort: "rownumber", 'first' | reverse %}
+        {% for net in nets %}
+        <tr>
+          <td>
+            {% if net.link %}
+            <a href={{net.link}}>{{net.name}}</a>
+            {% else %}
+            {{net.name}}
+            {% endif %}
+          </td>
+          <td>{{net.content}}</td>
+          <td>{{net.version}}</td>
+          <td>{{net.object}}</td>
+          <td>{% for download in net.downloads %}
+            {% if download.source != net.downloads[0].source %},&nbsp{% endif %}
+            <a href={{download.link}} target="_blank">{{download.source}}</a>
+          {% endfor %}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+    
+    {% assign libraries = site.libraries | group_by: "category" %}
+    {% for library in libraries %}
+    {% if library.name != "net" %}
 
-<div class="tab-content">
-  <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
-    <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label=".NET Libraries">
-      <tr>
-        <th width="20%">Name</th>
-        <th width="50%">Description</th>
-        <th width="10%">Support OData version(s)</th>
-        <th width="10%">For server/client</th>
-        <th width="10%">Download from</th>
-      </tr>
-      {% assign nets = site.libraries | where: "category", "net" | sort: "rownumber", 'first' | reverse %}
-      {% for net in nets %}
-      <tr>
-        <td>
-          {% if net.link %}
-          <a href={{net.link}}>{{net.name}}</a>
-          {% else %}
-          {{net.name}}
-          {% endif %}
-        </td>
-        <td>{{net.content}}</td>
-        <td>{{net.version}}</td>
-        <td>{{net.object}}</td>
-        <td>{% for download in net.downloads %}
-          {% if download.source != net.downloads[0].source %},&nbsp{% endif %}
-          <a href={{download.link}} target="_blank">{{download.source}}</a>
-        {% endfor %}</td>
-      </tr>
-      {% endfor %}
-    </table>
+    <div class="tab-pane" id="{{library.name}}" role="tabpanel" hidden>
+      <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label="{{library.name}} Libraries">
+        <tr>
+          <th width="20%">Name</th>
+          <th width="50%">Description</th>
+          <th width="10%">Support OData version(s)</th>
+          <th width="10%">For server/client</th>
+          <th width="10%">Download from</th>
+        </tr>
+        {% assign items = library.items | sort: "rownumber", 'first' | reverse %}
+        {% for item in items %}
+        <tr>
+          <td>{{item.name}}</td>
+          <td>{{item.content}}</td>
+          <td>{{item.version}}</td>
+          <td>{{item.object}}</td>
+          <td>{% for download in item.downloads %}
+            {% if download.source != item.downloads[0].source %},&nbsp{% endif %}
+            <a href={{download.link}} target="_blank">{{download.source}}</a>
+          {% endfor %}</td>
+        </tr>
+        {% endfor %}
+      </table>
+    </div>
+    {% endif %}
+    {% endfor %}
   </div>
-  
-  {% assign libraries = site.libraries | group_by: "category" %}
-  {% for library in libraries %}
-
-  <div class="tab-pane {% if forloop.first == true %}hide{% endif%}" id="{{library.name}}" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover" style="width:100%" role="presentation" aria-label="{{library.name}} Libraries">
-      <tr>
-        <th width="20%">Name</th>
-        <th width="50%">Description</th>
-        <th width="10%">Support OData version(s)</th>
-        <th width="10%">For server/client</th>
-        <th width="10%">Download from</th>
-      </tr>
-      {% assign items = library.items | sort: "rownumber", 'first' | reverse %}
-      {% for item in items %}
-      <tr>
-        <td>{{item.name}}</td>
-        <td>{{item.content}}</td>
-        <td>{{item.version}}</td>
-        <td>{{item.object}}</td>
-        <td>{% for download in item.downloads %}
-          {% if download.source != item.downloads[0].source %},&nbsp{% endif %}
-          <a href={{download.link}} target="_blank">{{download.source}}</a>
-        {% endfor %}</td>
-      </tr>
-      {% endfor %}
-    </table>
-  </div>
-  {% endfor %}
-</div>
 <div>
+</div>
   <h4>Contribute to OData Libraries</h4>
   <p>Want to add/update information of an OData library? You can edit and submit changes to this page on its <a href="https://github.com/ODataOrg/odataorg.github.io" target="_blank">Github repository</a>.</p>
 </div>

--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -5,15 +5,15 @@ date: 2014-02-20 06:56:35.000000000 +08:00
 permalink: /odata-services/
 ---
 <div id="services-tab">
-<ul class="nav nav-pills" role="tablist" aria-label="Versions"> 
+<ul class="nav nav-tabs" role="tablist" aria-label="Versions"> 
   <li role="presentation" class="active">
-    <a href="#odata-v4" aria-controls="odata-v4" data-toggle="tab">OData v4</a>
+    <a href="#odata-v4" role="tab" aria-controls="odata-v4" data-toggle="tab">OData v4</a>
   </li>
   <li role="presentation">
-    <a   href="#v3" data-toggle="tab" aria-controls="v3" tabindex="-1">OData v3</a>
+    <a  href="#v3" role="tab" data-toggle="tab" aria-controls="v3" tabindex="-1">OData v3</a>
   </li>
   <li role="presentation">
-    <a href="#v2" data-toggle="tab" aria-controls="v2" tabindex="-1">OData v2</a>
+    <a href="#v2" role="tab" data-toggle="tab" aria-controls="v2" tabindex="-1">OData v2</a>
   </li>
 </ul>
 

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -11,7 +11,7 @@
   generateArrays();
 
   function generateArrays () {
-    tabs = document.querySelectorAll('[data-toggle="tab"]');
+    tabs = document.querySelectorAll('[role="tab"]');
     panels = document.querySelectorAll('[role="tabpanel"]');
   };
 
@@ -40,7 +40,6 @@
   };
 
   function addListeners (index) {
-    tabs[index].addEventListener('click', clickEventListener);
     tabs[index].addEventListener('keydown', keydownEventListener);
     tabs[index].addEventListener('keyup', keyupEventListener);
 
@@ -94,7 +93,7 @@
     };
   };
 
-  // When a tablist’s aria-orientation is set to vertical,
+  // When a tablist's aria-orientation is set to vertical,
   // only up and down arrow should function.
   // In all other cases only left and right arrow function.
   function determineOrientation (event) {
@@ -151,19 +150,22 @@
     deactivateTabs();
 
     // Remove tabindex attribute
-    tab.removeAttribute('tabindex');
+    tab.setAttribute('tabindex', '0');
 
     // Set the tab as selected
+    tab.classList.add('active');
+    tab.parentElement.classList.add('active');
     tab.setAttribute('aria-selected', 'true');
 
     // Get the value of aria-controls (which is an ID)
     var controls = tab.getAttribute('aria-controls');
 
     // Remove hidden attribute from tab panel to make it visible
-    if(document.getElementById(controls))
-    {
-      document.getElementById(controls).removeAttribute('hidden');
-    }
+    var tabContent = document.getElementById(controls);
+    tabContent.removeAttribute('hidden');
+    tabContent.setAttribute('tabindex', '0');
+    tabContent.setAttribute('aria-hidden', 'false');
+    tabContent.classList.add('active');
 
     // Set focus when required
     if (setFocus) {
@@ -176,11 +178,16 @@
     for (t = 0; t < tabs.length; t++) {
       tabs[t].setAttribute('tabindex', '-1');
       tabs[t].setAttribute('aria-selected', 'false');
+      tabs[t].classList.remove('active');
+      tabs[t].parentElement.classList.remove('active');
       tabs[t].removeEventListener('focus', focusEventHandler);
     };
 
     for (p = 0; p < panels.length; p++) {
       panels[p].setAttribute('hidden', 'hidden');
+      panels[p].setAttribute('tabindex', '-1');
+      panels[p].setAttribute('aria-hidden', 'true');
+      panels[p].classList.remove('active');
     };
   };
 


### PR DESCRIPTION
.Previously '.Net', '.Java', 'JavaScript','C++','Other Platforms' are given as 'tab items' but now they are changed as 'Links' but those are accessible using arrow keys which is not proper. If those are defined as links they should be accessible using tab but not with arrow keys.

If those are defined as tab items then Narrator/NVDA shouldn't  read non selected tab item as selected.

Reverted nav-links to nav-tabs
Made updates to tabs.js to ensure that the tab content is shown when navigating via the arrows. 
Fixed indentation in the html
