### PR TITLE
Update postman links

### DIFF
--- a/pages/getting-started/learning-odata-on-postman.html
+++ b/pages/getting-started/learning-odata-on-postman.html
@@ -5,7 +5,7 @@ date: 2014-12-12 07:45:00.000000000 +08:00
 permalink: /getting-started/learning-odata-on-postman/
 ---
 <h2>Introduction</h2>
-<p>There are various ways to learn about OData and starting with the native HTTP request may be the most direct one. We have a series of <a href="">Basic Tutorials</a> and <a href="">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. We now provide an easier way to help you understand OData and contribute your own scenarios. We create a collection of OData HTTP requests using <a href="https://www.postman.com/">Postman on Chrome</a> - an efficient way to test, develop, and document APIs.</p>
+<p>There are various ways to learn about OData and starting with the native HTTP request may be the most direct one. We have a series of <a href="/getting-started/basic-tutorial">Basic Tutorials</a> and <a href="/getting-started/advanced-tutorial">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. We now provide an easier way to help you understand OData and contribute your own scenarios. We create a collection of OData HTTP requests using <a href="https://www.postman.com/">Postman</a> - an efficient way to test, develop, and document APIs.</p>
 <h2>How to Learn OData on Postman</h2>
 <p>It's quite easy for Chrome users to install the Postman tool and run the collections. Just follow the steps below :</p>
 <ul>
@@ -13,7 +13,7 @@ permalink: /getting-started/learning-odata-on-postman/
 <li>Import the collection
 <ul>
 <li>Click the "Import" button on the top bar.</li>
-<li>Choose download from link and paste the <a href="https://www.postman.com/collections/705714417adde4e687e4">POSTMAN collection URL</a>.</li>
+<li>Choose download from link and paste the <a href="https://www.postman.com/collections/705714417adde4e687e4">Postman collection URL</a>.</li>
 </ul>
 <p>    You can find more details of Postman collection in <a href="https://learning.postman.com/docs/sending-requests/intro-to-collections/">Postman collection docs.</a> After you successfully import the collection, you can see the query collection as below :
 </li>

--- a/pages/getting-started/learning-odata-on-postman.html
+++ b/pages/getting-started/learning-odata-on-postman.html
@@ -9,7 +9,7 @@ permalink: /getting-started/learning-odata-on-postman/
 <h2>How to Learn OData on Postman</h2>
 <p>It's quite easy for Chrome users to install the Postman tool and run the collections. Just follow the steps below :</p>
 <ul>
-<li>Install <a href="https://chrome.google.com/webstore/detail/postman-rest-client-packa/fhbjgbiflinjbdggehcddcbncdddomop">Postman packaged app</a></li>
+<li>Install <a href="https://www.postman.com/downloads/">Postman</a></li>
 <li>Import the collection
 <ul>
 <li>Click the "Import" button on the top bar.</li>

--- a/pages/getting-started/learning-odata-on-postman.html
+++ b/pages/getting-started/learning-odata-on-postman.html
@@ -5,7 +5,7 @@ date: 2014-12-12 07:45:00.000000000 +08:00
 permalink: /getting-started/learning-odata-on-postman/
 ---
 <h2>Introduction</h2>
-<p>There are various ways to learn about OData and start with the native HTTP request maybe the most direct one. We have a series of <a href="">Basic Tutorials</a> and <a href="">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. Now we provide an easier way to help you understand OData and also make it quite easy for you to contribute your own scenarios. We create a collections of HTTP requests of OData on <a href="https://www.postman.com/">Postman on Chrome</a>- an efficient way to test, develop and document APIs.</p>
+<p>There are various ways to learn about OData and starting with the native HTTP request may be the most direct one. We have a series of <a href="">Basic Tutorials</a> and <a href="">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. We now provide an easier way to help you understand OData and contribute your own scenarios. We create a collection of OData HTTP requests using <a href="https://www.postman.com/">Postman on Chrome</a> - an efficient way to test, develop, and document APIs.</p>
 <h2>How to Learn OData on Postman</h2>
 <p>It's quite easy for Chrome users to install the Postman tool and run the collections. Just follow the steps below :</p>
 <ul>

--- a/pages/getting-started/learning-odata-on-postman.html
+++ b/pages/getting-started/learning-odata-on-postman.html
@@ -5,7 +5,7 @@ date: 2014-12-12 07:45:00.000000000 +08:00
 permalink: /getting-started/learning-odata-on-postman/
 ---
 <h2>Introduction</h2>
-<p>There are various ways to learn about OData and start with the native HTTP request maybe the most direct one. We have a series of <a href="">Basic Tutorials</a> and <a href="">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. Now we provide an easier way to help you understand OData and also make it quite easy for you to contribute your own scenarios. We create a collections of HTTP requests of OData on <a href="http://www.getpostman.com/">Postman on Chrome</a>- an efficient way to test, develop and document APIs.</p>
+<p>There are various ways to learn about OData and start with the native HTTP request maybe the most direct one. We have a series of <a href="">Basic Tutorials</a> and <a href="">Advanced Tutorials</a> already, but these still ask you to copy&amp;paste the requests. Now we provide an easier way to help you understand OData and also make it quite easy for you to contribute your own scenarios. We create a collections of HTTP requests of OData on <a href="https://www.postman.com/">Postman on Chrome</a>- an efficient way to test, develop and document APIs.</p>
 <h2>How to Learn OData on Postman</h2>
 <p>It's quite easy for Chrome users to install the Postman tool and run the collections. Just follow the steps below :</p>
 <ul>
@@ -13,9 +13,9 @@ permalink: /getting-started/learning-odata-on-postman/
 <li>Import the collection
 <ul>
 <li>Click the "Import" button on the top bar.</li>
-<li>Choose download from link and paste the <a href="https://www.getpostman.com/collections/705714417adde4e687e4">POSTMAN collection URL</a>.</li>
+<li>Choose download from link and paste the <a href="https://www.postman.com/collections/705714417adde4e687e4">POSTMAN collection URL</a>.</li>
 </ul>
-<p>    You can find more details of POSTMAN collection in <a href="http://www.getpostman.com/docs/collections">POSTMAN collection docs.</a> After you successfully import the collection, you can see the query collection as below :
+<p>    You can find more details of POSTMAN collection in <a href="https://learning.postman.com/docs/sending-requests/intro-to-collections/">POSTMAN collection docs.</a> After you successfully import the collection, you can see the query collection as below :
 </li>
 </ul>
 <p>And the resources behind this is on <a href="https://github.com/ODataOrg/Tutorials">OData tutorial Guidelines</a>.</p>

--- a/pages/getting-started/learning-odata-on-postman.html
+++ b/pages/getting-started/learning-odata-on-postman.html
@@ -15,7 +15,7 @@ permalink: /getting-started/learning-odata-on-postman/
 <li>Click the "Import" button on the top bar.</li>
 <li>Choose download from link and paste the <a href="https://www.postman.com/collections/705714417adde4e687e4">POSTMAN collection URL</a>.</li>
 </ul>
-<p>    You can find more details of POSTMAN collection in <a href="https://learning.postman.com/docs/sending-requests/intro-to-collections/">POSTMAN collection docs.</a> After you successfully import the collection, you can see the query collection as below :
+<p>    You can find more details of Postman collection in <a href="https://learning.postman.com/docs/sending-requests/intro-to-collections/">Postman collection docs.</a> After you successfully import the collection, you can see the query collection as below :
 </li>
 </ul>
 <p>And the resources behind this is on <a href="https://github.com/ODataOrg/Tutorials">OData tutorial Guidelines</a>.</p>

--- a/pages/service-usages/request-key-tutorial.md
+++ b/pages/service-usages/request-key-tutorial.md
@@ -49,7 +49,7 @@ The first one is the same with the `Usages in Browsers`. And the other is to use
 #### Use Environment Concept in Postman
 
 1. To understand environment concept in postman, please refer to 
-[Setting up an environment with variables](https://www.getpostman.com/docs/environments).
+[Setting up an environment with variables](https://learning.postman.com/docs/sending-requests/managing-environments).
 
 2. Please import the postman collection which needs environment configuration to simplify the key configuration.
 [![Import Postman Collection For Write](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/7e8ea944a01c65d2cdc3)


### PR DESCRIPTION
Fixes #250 

Updates postman links from getpostman.com to postman.com domain.

I noticed that the Run Collection link still uses the app.getpostman.com, if you try to run https://app.postman.com/run-collection/7e8ea944a01c65d2cdc3, you get an error that it's unreachable. If you try to run https://postman.com/run-collection/7e8ea944a01c65d2cdc3 instead, then it redirects you to https://app.getpostman.com/run-collection/7e8ea944a01c65d2cdc3 (which is the original link). So I left it as is.

I also noticed that links to docs redirect to learning.postman.com/docs and I updated them accordingly.