### PR TITLE
Fix keyboard focus order inside modal and after modal

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -76,7 +76,7 @@ permalink: /getting-started/understand-odata-in-6-steps/
 <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button></p>
 <h4 class="modal-title" id="step-collection-modal-label">Response</h4>
 </p></div>
-<div class="modal-body sr-focusable">
+<div class="modal-body">
 {% highlight js %}
 HTTP/1.1 200 OK
 Content-Length: 1007
@@ -1357,11 +1357,12 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
        $('.modal').on('shown.bs.modal', function () {
             $('.close').focus();
             trapFocus(this)
-            $(this).find(".modal-body").attr("tabindex", 0);
+            $(this).find(".modal-body").attr("tabindex", -1);
        });
+       
         // make it possible to tab to response content inside popups for keyboard users
         $(".modal-body pre").attr("tabindex", 0);
-        $(".modal-body").attr("aria-label", "Response body");
+        $(".modal-title").attr("tabindex", 0);
         
         // hack to get the screen reader to read the syntax-highlighted
         // code section on Microsoft Edge
@@ -1371,13 +1372,13 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             $(modalBody).find("pre span").each(function (spanIndex, span) {
                 plainCode += span.textContent + ' ';
             });
-            
-            // inject paragraph with plain code for screen readers
-            var screenReaderContent = document.createElement("p");
-            screenReaderContent.classList.add("sr-only");
-            screenReaderContent.tabIndex = 0;
-            screenReaderContent.textContent = plainCode;
-            modalBody.insertBefore(screenReaderContent, modalBody.firstChild);
+                   
+            var codeBlock= $(modalBody).find("pre");
+            codeBlock.attr('aria-label', plainCode);
+
+            // first child will be the figure with the <pre> tag inside. Make it non-focusable.
+            var firstChild = modalBody.firstChild;
+            firstChild.attr('tabindex', -1)
         });
     });
        

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1359,10 +1359,11 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             trapFocus(this)
             $(this).find(".modal-body").attr("tabindex", -1);
        });
-
+       
         // make it possible to tab to response content inside popups for keyboard users
         $(".modal-body pre").attr("tabindex", 0);
-                
+        $(".modal-title").attr("tabindex", 0);
+        
         // hack to get the screen reader to read the syntax-highlighted
         // code section on Microsoft Edge
         $('.modal-body').each(function (i, modalBody) {

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -1359,11 +1359,10 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
             trapFocus(this)
             $(this).find(".modal-body").attr("tabindex", -1);
        });
-       
+
         // make it possible to tab to response content inside popups for keyboard users
         $(".modal-body pre").attr("tabindex", 0);
-        $(".modal-title").attr("tabindex", 0);
-        
+                
         // hack to get the screen reader to read the syntax-highlighted
         // code section on Microsoft Edge
         $('.modal-body').each(function (i, modalBody) {


### PR DESCRIPTION
Environment Details: 
#URL:https://www.odata.org/​

Browser Details: 
Edge Dev Version 84.0.508.0 (Official build) dev (64-bit)
Chrome Version 81.0.4044.138 (Official Build) (64-bit)
​
OS Details:​
Microsoft windows 10 enterprise ​
Version: 1909 Build 18363.836
​
Repro Steps: ​​​
1)Hit the URL "https://www.odata.org/"  to open Odata website​
2)Tab till 'Developers' link and press enter​
3)Tab till 'Getting Started' option and press enter​
4)Tab till 'Understand OData in 6 steps' link and press enter​
5)Tab till 'View the response' button and press enter​
6)Verify focus order is proper or not after the Content receives focus
​
Actual Result: ​​​
Focus order is not proper in the 'Response' popup. After the Content receives focus after that focus order is not proper, focus is going to the content again instead of going to 'close' button