### PR TITLE
Add missing tab roles and image alt texts

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -471,18 +471,18 @@ OData-Version: 4.0
 <p class="text-justify bottom-margin">As the REST principles go, "Everything is a Resource". As a simple start, let's see how resources can be retrieved from the OData RESTful APIs. The sample service used is the TripPin service which simulates the service of an open trip management system. Our friend, Russell Whyte, who has formerly registered TripPin, would like to find out who are the other people in it.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http1" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp1" id="csharpDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp1" role="tab" id="csharpDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop1" id="csharpDrop1-contents">
 <li><a href="#csharpCodeGen1" tabindex="-1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aira-controls="csharpCodeGen1">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData1" tabindex="-1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aira-controls="csharpSimpleOData1">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-1" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-1" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-1" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-1" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http1">
@@ -565,7 +565,7 @@ function getURL(url) {
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-1">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>
@@ -578,18 +578,18 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <p class="text-justify bottom-margin">REST principles also say, that every resource is identified by a unique identifier. OData also enables defining key properties of a resource and retrieving it using the keys. In this step, Russell wants to find the information about himself by specifying his username as the key.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http2" aria-controls="http2" data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http2" role="tab" aria-controls="http2" data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp2" id="csharpDrop2" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop2-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp2" role="tab" id="csharpDrop2" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop2-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop1" id="csharpDrop2-contents">
 <li><a href="#csharpCodeGen2" tabindex="-1" role="tab" id="csharpCodeGen2-tab" data-toggle="tab" aira-controls="csharpCodeGen2">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData2" tabindex="-1" role="tab" id="csharpSimpleOData2-tab" data-toggle="tab" aira-controls="csharpSimpleOData2">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-2" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-2" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-2" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-2" aria-controls="contribute-2" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-2" role="tab" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-2" role="tab" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-2" role="tab" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-2" role="tab" aria-controls="contribute-2" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http2">
@@ -673,7 +673,7 @@ function getURL(url) {
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-2">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>
@@ -686,18 +686,18 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <p class="text-justify bottom-margin">As an architecture that's built on top of the current features of the Web, RESTful APIs can also support query strings. For that, OData defines a series of system query options that can help you construct complicated queries for the resources you want. With the help of that, our friend Russell can find out the first 2 persons in the system who have registered at least one trip that costs more than 3000, and only display their first name and last name.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http3" aria-controls="http3" data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http3" role="tab" aria-controls="http3" data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp3" id="csharpDrop3" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop3-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp3" role="tab" id="csharpDrop3" role="tab" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop3-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop3" id="csharpDrop3-contents">
 <li><a href="#csharpCodeGen3" tabindex="-1" role="tab" id="csharpCodeGen3-tab" data-toggle="tab" aira-controls="csharpCodeGen3">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData3" tabindex="-1" role="tab" id="csharpSimpleOData3-tab" data-toggle="tab" aira-controls="csharpSimpleOData3">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-3" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-3" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-3" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-3" aria-controls="contribute-3" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-3" role="tab" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-3" role="tab" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-3" role="tab" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-3" role="tab" aria-controls="contribute-3" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http3">
@@ -790,7 +790,7 @@ function getURL(url) {
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-3">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>
@@ -803,18 +803,18 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <p class="text-justify bottom-margin">REST principles require the using of simple and uniform interfaces. With that regard, OData clients can expect unified interfaces of the resources. The stateless transfer of representations in REST are carried out by using different HTTP methods in the requests. After having gone through the first 3 steps, Russell thinks the system is useful. He wants to add his best friend Lewis to the system. He finds out that all he needs to do is to send a POST request containing a JSON representation of Lewis' information to the same interface from which he requested the people information.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http4" aria-controls="http4"  data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http4" role="tab" aria-controls="http4"  data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp4" id="csharpDrop4" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop4-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp4" role="tab" id="csharpDrop4" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop4-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop4" id="csharpDrop4-contents">
 <li><a href="#csharpCodeGen4" tabindex="-1" role="tab" id="csharpCodeGen4-tab" data-toggle="tab" aira-controls="csharpCodeGen4">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData4" tabindex="-1" role="tab" id="csharpSimpleOData4-tab" data-toggle="tab" aira-controls="csharpSimpleOData4">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-4" aria-controls="olingo-js-4" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-4" aria-controls="odatacpp-4" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-4" aria-controls="nodejs-4" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-4" aria-controls="contribute-4" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-4" role="tab" aria-controls="olingo-js-4" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-4" role="tab" aria-controls="odatacpp-4" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-4" role="tab" aria-controls="nodejs-4" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-4" role="tab" aria-controls="contribute-4" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http4">
@@ -1053,7 +1053,7 @@ req.end();
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-4">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>
@@ -1066,18 +1066,18 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <p class="text-justify bottom-margin">In RESTful APIs, resources are usually dependent with each other. For that, the concept of relationships in OData can be defined among resources to add flexibility and richness to the data model. For example, in the TripPin OData service, people are related to the trips that they've booked using the system. Knowing that, Russell would like to invite Lewis to his existing trip in the U.S. by relating that trip to Lewis.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http5" aria-controls="http5"  data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http5" role="tab" aria-controls="http5"  data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp5" id="csharpDrop5" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop5-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp5" role="tab" id="csharpDrop5" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop5-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop5" id="csharpDrop5-contents">
 <li><a href="#csharpCodeGen5" tabindex="-1" role="tab" id="csharpCodeGen5-tab" data-toggle="tab" aira-controls="csharpCodeGen5">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData5" tabindex="-1" role="tab" id="csharpSimpleOData5-tab" data-toggle="tab" aira-controls="csharpSimpleOData5">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-5" aria-controls="olingo-js-5" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-5" aria-controls="odatacpp-5" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-5" aria-controls="nodejs-5" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-5" aria-controls="contribute-5" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-5" role="tab" aria-controls="olingo-js-5" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-5" role="tab" aria-controls="odatacpp-5" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-5" role="tab" aria-controls="nodejs-5" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-5" role="tab" aria-controls="contribute-5" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http5">
@@ -1221,7 +1221,7 @@ req.end();
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-5">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>
@@ -1234,18 +1234,18 @@ Download and install the Node.js platform from <a href="http://nodejs.org">nodej
 <p class="text-justify bottom-margin">In RESTful APIs, there can be some custom operations that contain complicated logic and can be frequently used. For that purpose, OData supports defining functions and actions to represent such operations. They are also resources themselves and can be bound to existing resources. After having explored the TripPin OData service, Russell finds out that the it has a function called GetInvolvedPeople from which he can find out the involved people of a specific trip. He invokes the function to find out who else other than him and Lewis goes to that trip in the U.S.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a href="#http6" aria-controls="http6"  data-toggle="tab">HTTP request</a></li>
+<li role="presentation" class="active"><a href="#http6" role="tab" aria-controls="http6"  data-toggle="tab">HTTP request</a></li>
 <li role="presentation" class="dropdown">
-<a href="#csharp6" id="csharpDrop6" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
+<a href="#csharp6" role="tab" id="csharpDrop6" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu" role="menu" aria-labelledby="csharpDrop6" id="csharpDrop6-contents">
 <li><a href="#csharpCodeGen6" tabindex="-1" role="tab" id="csharpCodeGen6-tab" data-toggle="tab" aira-controls="csharpCodeGen6">OData v4 Client Code Generator</a></li>
 <li><a href="#csharpSimpleOData6" tabindex="-1" role="tab" id="csharpSimpleOData6-tab" data-toggle="tab" aira-controls="csharpSimpleOData6">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a href="#olingo-js-6" aria-controls="olingo-js-6" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a href="#odatacpp-6" aria-controls="odatacpp-6" data-toggle="tab">C++</a></li>
-<li role="presentation"><a href="#nodejs-6" aria-controls="nodejs-6" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a href="#contribute-6" aria-controls="contribute-6" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a href="#olingo-js-6" role="tab" aria-controls="olingo-js-6" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a href="#odatacpp-6" role="tab" aria-controls="odatacpp-6" data-toggle="tab">C++</a></li>
+<li role="presentation"><a href="#nodejs-6" role="tab" aria-controls="nodejs-6" data-toggle="tab">Node.js</a></li>
+<li role="presentation"><a href="#contribute-6" role="tab" aria-controls="contribute-6" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http6">
@@ -1345,7 +1345,7 @@ function getURL(url) {
 Download and install the Node.js platform from <a href="http://nodejs.org">nodejs.org</a> then run the snippets below using the node command. The code is contributed by <a href="https://github.com/markpete">Mark Peterson</a>
 </div>
 <div role="tabpanel" class="tab-pane" id="contribute-6">
-<img class="github-logo" src="assets/Octocat.png" /></p>
+<img class="github-logo" alt="GitHub logo" src="assets/Octocat.png" /></p>
 <h4>Contribute to "Understanding OData in 6 steps"</h4>
 <p>Want to contribute code snippet for another platform or suggest changes to this content? You can edit and submit changes to "Understanding OData in 6 steps" on its <a href="https://github.com/ODataOrg/home-samples" target="_blank">Github repository</a>.
 </div>


### PR DESCRIPTION
Fix #266 

And `tab` roles to tab item links in the "Understanding OData in 6 Steps" page.

Prior to this change, the screen reader (Windows Narrator) reads the items as links. After this change, it reads the items as "tab item" and also says how many tab items there are (e.g. tab item 4 of 6).

I also added missing alt texts to images on that page.