### PR TITLE
Fix basic tutorial page zooming issue

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,7 +45,8 @@
 </script>
 
   <link rel="stylesheet" href="https://www.odata.org/public/css/bootstrap.min.css"/>
-  <link rel="stylesheet" href="{{'/public/css/site.css' | prepend: site.baseurl | prepend: site.url}}">
+  <link rel="stylesheet" href="{{'/public/css/site.css'}}">
+  <!-- <link rel="stylesheet" href="{{'/public/css/site.css' | prepend: site.baseurl | prepend: site.url}}"> -->
   <link rel="stylesheet" href="{{'/public/css/syntax.css' | prepend: site.baseurl | prepend: site.url}}">
   <link rel="stylesheet" href="{{'/public/css/autocomplete.css' | prepend: site.baseurl | prepend: site.url}}">
   <!--Below is for the adopters page-->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,8 +45,7 @@
 </script>
 
   <link rel="stylesheet" href="https://www.odata.org/public/css/bootstrap.min.css"/>
-  <link rel="stylesheet" href="{{'/public/css/site.css'}}">
-  <!-- <link rel="stylesheet" href="{{'/public/css/site.css' | prepend: site.baseurl | prepend: site.url}}"> -->
+  <link rel="stylesheet" href="{{'/public/css/site.css' | prepend: site.baseurl | prepend: site.url}}">
   <link rel="stylesheet" href="{{'/public/css/syntax.css' | prepend: site.baseurl | prepend: site.url}}">
   <link rel="stylesheet" href="{{'/public/css/autocomplete.css' | prepend: site.baseurl | prepend: site.url}}">
   <!--Below is for the adopters page-->

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,3 +1,4 @@
+<div role="banner">
 <a class="sr-only sr-only-focusable" href="#main-content"><h4 role="presentation">Skip to main content</h4></a>
 <nav class="navbar navbar-default" role="navigation" aria-label="Main Navigation">
     <div class="container container-fluid">
@@ -60,3 +61,4 @@
         </div>
     </div>
 </nav>
+</div>

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -1024,3 +1024,6 @@ HTTP/1.1 204 No Content
 </div>
 
 <!--/body-->
+<script type="text/javascript">
+    $(".page-header").css({"width":"66.66%"});
+</script>

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -6,13 +6,13 @@ permalink: /getting-started/basic-tutorial/
 ---
 <!--body data-spy="scroll" data-target="nav"-->
 <div class="row">
-<div class="col-md-8">
+<div class="col-2-3">
 <p>            The Open Data Protocol (OData) is a data access protocol built on core protocols like HTTP and commonly accepted methodologies like REST for the web. There are various kinds of <a href="https://www.odata.org/libraries/">libraries</a> and <a href="https://www.odata.org/ecosystem/">tools</a>  can be used to consume OData services. But for beginners and those who want to write their own libraries, the pure HTTP requests and responses are also very important. This documentation will not cover every feature details for OData V4 services but will try to cover various typical scenarios.  If you want to have a more detailed understanding, please refer to <a href="https://www.odata.org/documentation/">OData Documentation</a>. </p>
 <p>        You can now use the <b><a href="https://www.odata.org/getting-started/learning-odata-on-postman">Postman collections</a></b> to learn OData in an interactive way.</p>
 <h4>Please note:</h4>
 <ul>
 <li>This is the Basic section. For topics like Singleton, Inheritance, Open Type, Containment and Batch, please refer to <a href="https://www.odata.org/getting-started/advanced-tutorial/">Advanced Section</a>.</li>
-<li>All these are based on OData V4 sample service <a href="https://services.odata.org/V4/TripPinServiceRW">TripPin</a>, please just replace the <code>serviceRoot</code> below with the URL <code>https://services.odata.org/V4/TripPinServiceRW</code>. TripPin now supports ETag, so for data modification topics, you should first using GET on TripPin (eg. GET serviceRoot/People) to get the section information in the payload then use the URL with section for data modification examples. (something looks like https://services.odata.org/V4/(S(flat4rgegiueineatspfdku1))/TripPinServiceRW)</li>
+<li>All these are based on OData V4 sample service <a href="https://services.odata.org/V4/TripPinServiceRW">TripPin</a>, please just replace the <code>serviceRoot</code> below with the URL <code>https://services.odata.org/V4/TripPinServiceRW</code>. TripPin now supports ETag, so for data modification topics, you should first using GET on TripPin (eg. GET serviceRoot/People) to get the section information in the payload then use the URL with section for data modification examples. (something looks like <code>https://services.odata.org/V4/(S(flat4rgegiueineatspfdku1))/TripPinServiceRW)</code></li>
 <li>You may use <a href="http://www.telerik.com/fiddler">Fiddler</a> to run the request (especially the complex ones of data modification) and get the JSON response.</li>
 <li>In TripPin service, ETag is currently enabled on entity <em>Person</em>. We omit the ETag related headers in request headers for short, please go to the <a href="https://www.odata.org/getting-started/basic-tutorial/#etag">ETag Section</a> for detailed information.</li>
 <li>We will keep improving this by adding contents and fixing bugs. You can provide your feedbacks and ask questions using <a href="https://www.odata.org/join-the-odata-discussion/">OData Mailling List</a>.</li>
@@ -980,11 +980,11 @@ HTTP/1.1 204 No Content
 </p></div>
 </p></div>
 </div>
-<div class="col-md-1"></div>
-<div class="col-md-3">
+<div class="col-1-12"></div>
+<div class="col-1-4" id="tutorial-contents">
 
-<nav class="tutorial-sidebar" aria-label="Table of contents">
-<ul class="nav tutorial-sidenav" data-spy="affix">
+<nav class="tutorial-sidebar affix" aria-label="Table of contents" >
+<ul class="nav tutorial-sidenav">
 <li class="active">
             <a href="#requestData">Requesting Data</a></p>
 <ul class="nav">

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -191,7 +191,7 @@ code {
   }
 }
 
- @media (min-width:992px) {
+@media (min-width:992px) {
     .tutorial-sidebar .nav>.active>ul {
     display: block;
 	}

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -92,6 +92,7 @@ code {
     color: #ce3512;
     background-color: #f9f2f4;
     border-radius: 4px;
+    overflow-wrap: break-word;
 }
 .table {
   width: 100%;
@@ -182,16 +183,73 @@ code {
 	top: 50px;
 }
 
-@media (max-width: 991px) {
+/*@media (max-width: 991px) {
   .affix {
     position: static;
 	display: block;
 	float:right;
+    top: 50px;
   }
-}
+}*/
 
-@media (min-width:992px) {
+ @media (min-width:992px) {
     .tutorial-sidebar .nav>.active>ul {
     display: block;
 	}
+} 
+
+
+
+@media (max-height: 480px) {
+  .affix {
+    position: fixed;
+    top: 50px;
+  }
+}
+
+/*@media (max-height: 360px) {
+  .affix {
+    position: fixed;
+    top: 20%;
+  }
+}
+*/
+/*.tutorial-sidebar .affix {
+    top: 50px;
+}
+*/
+body {
+  overflow-x: hidden;
+}
+
+[class*='col-'] {
+  float: left;
+  padding-right: $pad;
+  .grid &:last-of-type {
+    padding-right: 0;
+  }
+}
+.col-2-3 {
+  width: 66.66%;
+}
+.col-1-3 {
+  width: 33.33%;
+}
+.col-1-2 {
+  width: 50%;
+}
+.col-1-4 {
+  width: 25%;
+}
+.col-1-8 {
+  width: 12.5%;
+}
+.col-1-12 {
+  width: 8.33%;
+}
+.col-3-4 {
+  width: 75%;
+}
+.col-3-8 {
+  width: 37.5%;
 }

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -164,7 +164,6 @@ code {
 }
 .tutorial-sidebar.affix {
     position: fixed;
-    top: 20px;
 }
 .tutorial-sidebar.affix-bottom {
     position: absolute;
@@ -183,14 +182,14 @@ code {
 	top: 50px;
 }
 
-/*@media (max-width: 991px) {
+@media (max-width: 991px) {
   .affix {
     position: static;
-	display: block;
-	float:right;
-    top: 50px;
+  	display: block;
+  	float:right;
+    top: 50%;
   }
-}*/
+}
 
  @media (min-width:992px) {
     .tutorial-sidebar .nav>.active>ul {
@@ -200,12 +199,12 @@ code {
 
 
 
-@media (max-height: 480px) {
+/*@media (max-height: 480px) {
   .affix {
     position: fixed;
     top: 50px;
   }
-}
+}*/
 
 /*@media (max-height: 360px) {
   .affix {


### PR DESCRIPTION
Fixes multiple issues:

- Add missing "role=banner" to navigation div
- Fix reflow of page to remove horizontal scrolling
- Ensure page controls don't disappear when zooming

Before
![basic tutorial - before](https://user-images.githubusercontent.com/1733185/117624191-53ce7600-b17d-11eb-9f1c-043651b80178.jpg)

After
![basic tutorial - after](https://user-images.githubusercontent.com/1733185/117624227-5df07480-b17d-11eb-9594-84f3503ac166.jpg)
