### PR TITLE
Fix table structure such that Summary of References table headers are read by screen readers

### DIFF
--- a/pages/documentation/terminology.html
+++ b/pages/documentation/terminology.html
@@ -10,11 +10,13 @@ permalink: /documentation/odata-version-2-0/terminology/
 <h2 role="heading">Summary of References:</h2>
 <div>
 <table border="1" cellspacing="0" cellpadding="0" role="presentation" aria-label="Summary of References">
+    <thead>
+        <tr>
+            <th valign="top" width="151">Reference</th>
+            <th valign="top" width="487">Description</th>
+        </tr>
+    </thead>
 <tbody>
-<tr>
-<th valign="top" width="151">Reference</th>
-<th valign="top" width="487">Description</th>
-</tr>
 <tr>
 <td valign="top" width="151">[<a href="http://tools.ietf.org/html/rfc2616">RFC 2616</a>]</td>
 <td valign="top" width="487">The HTTP protocol</td>


### PR DESCRIPTION
### Description
Fix table structure such that [Summary of References](https://www.odata.org/documentation/odata-version-2-0/terminology/) table headers are read by screen readers

### Repro Steps:​
 Hit the URL https://www.odata.org/ and login with appropriate credentials to open Odata website.
Tab till 'Developers' link and press enter.
Tab till 'Documentation' option and press enter.
Tab till "OData Version 2.0" link and press enter.
Tab till "OData Version 2.0 Terminology" link and press enter.
Verify all the controls in the "Terminology(OData Version 2.0)" are accessible.
Verify, whether table structure is properly defined or not

### Actual Result:
Table structure is not defined for the table data present under Developers-OData Version 2.0 Terminology page. Screen reader does not pass the table header or cell value information.

### Expected Result:
Table structure should be defined for the table data present under Developers-OData Version 2.0 Terminology page. Screen should pass the table cell value with table header with position.
