### PR TITLE
Fix keyboard access to scrollable content.

### DIFF
--- a/pages/documentation/common-schema-definition-language-csdl.html
+++ b/pages/documentation/common-schema-definition-language-csdl.html
@@ -1208,7 +1208,7 @@ permalink: /documentation/odata-version-3-0/common-schema-definition-language-cs
 </Schema>
 {% endhighlight %}
 <h1 id="csdl18">18 Informative XSD for CSDL</h1>
-<pre><?xml version="1.0" encoding="utf-8"?>
+<pre tabindex="0"><?xml version="1.0" encoding="utf-8"?>
 <xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:annotation="http://schemas.microsoft.com/ado/2009/02/edm/annotation" xmlns:cg="http://schemas.microsoft.com/ado/2006/04/codegeneration" xmlns:edm="http://schemas.microsoft.com/ado/2009/11/edm" targetNamespace="http://schemas.microsoft.com/ado/2009/11/edm">
   <xs:annotation>
     <xs:documentation xml:lang="en">


### PR DESCRIPTION
Scrollable region under ‘Informative XSD for CSDL’ is not accessible by keyboard.