### PR TITLE
Renaming "table of contents" to "page contents" for sidebar.

### DIFF
--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -678,50 +678,49 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 </p></div>
 </div>
 <div class="col-md-3" style="float:right">
-
-    <nav class="tutorial-sidebar" role="complementary" aria-label="Page Contents">
-    <ul class="nav tutorial-sidenav" role="navigation" data-spy="affix">
-    <li class="active">
-                            <a href="#singleton">Singleton</a></p>
-    <ul class="nav">
-    <li><a href="#querySingleton">Requesting Singleton</a></li>
-    <li><a href="#querySingletonProperty">Requesting Property of Singleton Property</a></li>
-    <li><a href="#updateSingleton">Update Singleton</a></li>
-    </ul>
-    </li>
-    <li>
-                            <a href="#derived">Derived Entity Type</a></p>
-    <ul class="nav">
-    <li><a href="#requestDerivedEntitySet">Requesting a Derived Entity Collection</a></li>
-    <li><a href="#requestDerived">Requesting a Derived Entity</a></li>
-    <li><a href="#filterDerived">Querying on Derived Entities</a></li>
-    <li><a href="#createDerived">Create a Derived Entity</a></li>
-    <li><a href="#updateDerived">Update a Derived Entity</a></li>
-    <li><a href="#deleteDerived">Delete a Derived Entity</a></li>
-    </ul>
-    </li>
-    <li>
-                            <a href="#containment">Containment Navigation Property</a></p>
-    <ul class="nav">
-    <li><a href="#queryContained">Requesting a Contained Entity Set</a></li>
-    <li><a href="#createContain">Create a Contained Entity</a></li>
-    <li><a href="#filterContain">Filter on a Contained Entity Set</a></li>
-    <li><a href="#updateContainment">Update a Contained Entity</a></li>
-    <li><a href="#deleteContainment">Delete a Contained Entity</a></li>
-    </ul>
-    </li>
-    <li>
-                            <a href="#openType">Open Type</a></p>
-    <ul class="nav">
-    <li><a href="#openEntity">Open Entity Type</a></li>
-    <li><a href="#openComplex">Open Complex Type</a></li>
-    </ul>
-    </li>
-    <li>
-                            <a href="#batch">Batch</a>
-                        </li>
-    </ul>
+    <nav class="tutorial-sidebar" aria-label="Page Contents">
+        <ul class="nav tutorial-sidenav" data-spy="affix">
+            <li class="active">
+                <a href="#singleton">Singleton</a></p>
+                <ul class="nav">
+                    <li><a href="#querySingleton">Requesting Singleton</a></li>
+                    <li><a href="#querySingletonProperty">Requesting Property of Singleton Property</a></li>
+                    <li><a href="#updateSingleton">Update Singleton</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#derived">Derived Entity Type</a></p>
+                <ul class="nav">
+                    <li><a href="#requestDerivedEntitySet">Requesting a Derived Entity Collection</a></li>
+                    <li><a href="#requestDerived">Requesting a Derived Entity</a></li>
+                    <li><a href="#filterDerived">Querying on Derived Entities</a></li>
+                    <li><a href="#createDerived">Create a Derived Entity</a></li>
+                    <li><a href="#updateDerived">Update a Derived Entity</a></li>
+                    <li><a href="#deleteDerived">Delete a Derived Entity</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#containment">Containment Navigation Property</a></p>
+                <ul class="nav">
+                    <li><a href="#queryContained">Requesting a Contained Entity Set</a></li>
+                    <li><a href="#createContain">Create a Contained Entity</a></li>
+                    <li><a href="#filterContain">Filter on a Contained Entity Set</a></li>
+                    <li><a href="#updateContainment">Update a Contained Entity</a></li>
+                    <li><a href="#deleteContainment">Delete a Contained Entity</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#openType">Open Type</a></p>
+                <ul class="nav">
+                    <li><a href="#openEntity">Open Entity Type</a></li>
+                    <li><a href="#openComplex">Open Complex Type</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#batch">Batch</a>
+            </li>
+        </ul>
     </nav>
-    </div>
+</div>
 <div class="col-md-1"></div>
 </div>

--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -679,8 +679,8 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 </div>
 <div class="col-md-3" style="float:right">
 
-    <nav class="tutorial-sidebar" aria-label="Table of contents">
-    <ul class="nav tutorial-sidenav" data-spy="affix">
+    <nav class="tutorial-sidebar" role="complementary" aria-label="Page Contents">
+    <ul class="nav tutorial-sidenav" role="navigation" data-spy="affix">
     <li class="active">
                             <a href="#singleton">Singleton</a></p>
     <ul class="nav">

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -983,8 +983,8 @@ HTTP/1.1 204 No Content
 <div class="col-1-12"></div>
 <div class="col-1-4" id="tutorial-contents">
 
-<nav class="tutorial-sidebar affix" aria-label="Table of contents" >
-<ul class="nav tutorial-sidenav">
+<nav class="tutorial-sidebar affix" role="complementary" aria-label="Page Contents" >
+<ul class="nav tutorial-sidenav" role="navigation">
 <li class="active">
             <a href="#requestData">Requesting Data</a></p>
 <ul class="nav">

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -982,44 +982,43 @@ HTTP/1.1 204 No Content
 </div>
 <div class="col-1-12"></div>
 <div class="col-1-4" id="tutorial-contents">
-
-<nav class="tutorial-sidebar affix" role="complementary" aria-label="Page Contents" >
-<ul class="nav tutorial-sidenav" role="navigation">
-<li class="active">
-            <a href="#requestData">Requesting Data</a></p>
-<ul class="nav">
-<li><a href="#entitySet">Requesting Entity Collections</a></li>
-<li><a href="#entityByID">Requesting an Individual Entity by ID</a></li>
-<li><a href="#property">Requesting an Individual Property</a></li>
-<li><a href="#propertyVal">Requesting an Individual Property Raw Value</a></li>
-</ul>
-</li>
-<li>
-            <a href="#queryData">Querying Data</a></p>
-<ul class="nav">
-<li><a href="#filter">System Query Option $filter</a></li>
-<li><a href="#orderby">System Query Option $orderby</a></li>
-<li><a href="#topskip">System Query Option $top and $skip</a></li>
-<li><a href="#count">System Query Option $count</a></li>
-<li><a href="#expand">System Query Option $expand</a></li>
-<li><a href="#select">System Query Option $select</a></li>
-<li><a href="#search">System Query Option $search</a></li>
-<li><a href="#lambda">Lambda Operators</a></li>
-</ul>
-</li>
-<li>
-            <a href="#modifyData">Data Modification</a></p>
-<ul class="nav">
-<li><a href="#create">Create an Entity</a></li>
-<li><a href="#delete">Delete an Entity</a></li>
-<li><a href="#update">Update an Entity</a></li>
-<li><a href="#relationship">Relationship Operations</a></li>
-<li><a href="#operation">Functions and Actions</a></li>
-<li><a href="#etag">ETag</a></li>
-</ul>
-</li>
-</ul>
-</nav>
+    <nav class="tutorial-sidebar affix" aria-label="Page Contents">
+        <ul class="nav tutorial-sidenav">
+            <li class="active">
+                <a href="#requestData">Requesting Data</a></p>
+                <ul class="nav">
+                    <li><a href="#entitySet">Requesting Entity Collections</a></li>
+                    <li><a href="#entityByID">Requesting an Individual Entity by ID</a></li>
+                    <li><a href="#property">Requesting an Individual Property</a></li>
+                    <li><a href="#propertyVal">Requesting an Individual Property Raw Value</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#queryData">Querying Data</a></p>
+                <ul class="nav">
+                    <li><a href="#filter">System Query Option $filter</a></li>
+                    <li><a href="#orderby">System Query Option $orderby</a></li>
+                    <li><a href="#topskip">System Query Option $top and $skip</a></li>
+                    <li><a href="#count">System Query Option $count</a></li>
+                    <li><a href="#expand">System Query Option $expand</a></li>
+                    <li><a href="#select">System Query Option $select</a></li>
+                    <li><a href="#search">System Query Option $search</a></li>
+                    <li><a href="#lambda">Lambda Operators</a></li>
+                </ul>
+            </li>
+            <li>
+                <a href="#modifyData">Data Modification</a></p>
+                <ul class="nav">
+                    <li><a href="#create">Create an Entity</a></li>
+                    <li><a href="#delete">Delete an Entity</a></li>
+                    <li><a href="#update">Update an Entity</a></li>
+                    <li><a href="#relationship">Relationship Operations</a></li>
+                    <li><a href="#operation">Functions and Actions</a></li>
+                    <li><a href="#etag">ETag</a></li>
+                </ul>
+            </li>
+        </ul>
+    </nav>
 </div>
 </div>
 


### PR DESCRIPTION
**Repro Steps:**
Hit the URL https://www.odata.org/  to open Odata website.
Tab till 'Developers' link and press enter
Tab till 'Getting Started' option and press enter.
Tab till "Basic tutorial" link and press enter.
Verify if screen reader announces incorrect information or not.

**Actual Result:**
Screen reader passes wrong information related to table on ‘Request Data’ link. Screen reader passes the wrong information as Table control.

**Expected Result:**
Screen reader should pass the correct information as link.

**Note:**
This issue also exists with NVDA, Narrator.
The issue exists throughout the application.

**Fixed by:**
Renaming "Table of contents" to "Page Contents" to reduce confusion on whether the element is a table
Also fixed for the Advanced Tutorial page sidebar nav which had a similar title.