### PR TITLE
Fix a-hover background color on dropdown links

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -327,3 +327,7 @@ pre {
   margin-left: 20%;
   margin-right: auto;
 }
+
+.dropdown-menu li a:hover {
+  background-color: #c34113;
+}


### PR DESCRIPTION
Repro
- Hit the URL https://www.odata.org/
- Tab till 'Developers' link and press enter
- Tab till 'Libraries' option and press enter
- Open color contrast analyser tool and verify the issue.
- The contrast when a drop down element is selected or hovered is below 4.5:1

Fix
Update the background color of `.dropdown-menu li a:hover` to be similar to the background color of `.navbar-nav>.open>a:focus`