### PR TITLE
Fix programmatic access for dropdown menu

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -30,13 +30,14 @@
                     <li class="dropdown" role="none">
                         <a role="menuitem"
                            aria-haspopup="true"
+                           aria-expanded="false"
                            class="dropdown-toggle"
                            data-toggle="dropdown"
                            data-target="#"
                            href="#">
                             Developers <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" role="menu">
+                        <ul class="dropdown-menu" role="menu" aria-label="Developers dropdown.">
                             <li role="none">
                                 <a role="menuitem" href="/getting-started">Getting Started</a>
                             </li>
@@ -57,13 +58,14 @@
                     <li class="dropdown" role="none">
                         <a role="menuitem"
                            aria-haspopup="true"
+                           aria-expanded="false"
                            class="dropdown-toggle"
                            data-toggle="dropdown"
                            data-target="#"
                            href="#">
                             Tools <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" role="menu">
+                        <ul class="dropdown-menu" role="menu" aria-label="Tools dropdown.">
                             <li role="none">
                                 <a role="menuitem"
                                    href="https://marketplace.visualstudio.com/items?itemName=stansw.vscode-odata"

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -138,8 +138,14 @@
             $("span.cell-content").contents().unwrap();
         }
     }
-</script>
-<script type="text/javascript">
+    $(".dropdown").on("show.bs.dropdown", function(event){
+       $(this).children('a[role=menuitem]').attr('aria-expanded', true);
+    });
+
+    $(".dropdown").on("hide.bs.dropdown", function(event){
+        $(this).children('a[role=menuitem]').attr('aria-expanded', false);
+    });
+
     // open the modal
     function openModal() {
       document.getElementById("screenshot1").style.display = "block";


### PR DESCRIPTION
The parent of the menuitem children is marked with role="menu". Assistive technologies can inform users that the managing control is a menu. In addition, the menu has been given an accessible name by adding an aria-label attribute to the parent element.

Also fixes the dropdown so that it can announce when the sub menu items are expanded.