### PR TITLE
Update batch-processing-v3.html

### DIFF
--- a/pages/documentation/batch-processing-v3.html
+++ b/pages/documentation/batch-processing-v3.html
@@ -39,11 +39,12 @@ Content-Type: multipart/mixed; boundary=batch_36522ad7-fc75-4b56-8c71-56071383e7
 <p>The example below shows a sample batch request that contains the following operations in the order listed:</p>
 <ul>
 <li>Query request</li>
-<li>A Change Set that contains the following requests:</li>
+<li>A Change Set that contains the following requests:
 <ul>
 <li>Insert entity</li>
 <li>Update request</li>
 </ul>
+</li>
 <li>Second query request</li>
 </ul>
 <pre><code>POST /service/$batch HTTP/1.1 
@@ -100,11 +101,12 @@ Host: host
 <p>If a MIME part representing an Insert request within a ChangeSet includes a Content-ID header, then the new entity represented by that part may be referenced by subsequent requests within the same ChangeSet by referring to the Content-ID value prefixed with a “$” character. When used in this way, $&lt;contentIdValue&gt; acts as an alias for the URI that identifies the new entity.</p>
 <p>The example below shows a sample batch request that contains the following operations in the order listed:</p>
 <ul>
-<li>A ChangeSet that contains the following requests:</li>
+<li>A ChangeSet that contains the following requests:
 <ul>
 <li>Insert a new entity (with Content-ID = 1)</li>
 <li>Insert a second new entity (references request with Content-ID = 1)</li>
 </ul>
+</li>
 </ul>
 <pre><code>POST /service/$batch HTTP/1.1 
 Host: host 


### PR DESCRIPTION
`A <ul> or <ol> element must directly contain only <li> , <script> or <template> elements`

**Why it matters**
```
In a properly structured list, all content is contained within list items. Content includes text and other HTML elements. Certain non-content elements are also allowed.

When an assistive technology encounters a list that’s poorly structured or contains disallowed elements, it might respond in an unexpected way. As a result, people who use assistive technologies might find it difficult to interpret the list.

```
**How to fix**
```
For each ordered or unordered list ( <ol> or <ul> element):

Make sure all list content is contained within <li> elements.
Don’t use a role attribute to override the native semantics of a <li> element.
If you include any other HTML elements, enclose them within <li> elements.
```