### PR TITLE
Update reference-service.html Tabs

### DIFF
--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -4,16 +4,48 @@ title: Reference Services
 date: 2014-02-20 06:56:35.000000000 +08:00
 permalink: /odata-services/
 ---
+
+<style>
+.btn {
+color: #f58d42;
+background-color: white;
+}
+
+.btn:hover{
+color: #f58d42;
+background-color: white;
+}
+
+.btn bottom.active  {
+}
+
+.btn:focus  {
+color: #f58d42;
+}
+
+
+</style>
+
+<script>
+function activateTabsById(id) 
+{
+ document.getElementById('btn1').className = "btn";
+ document.getElementById('btn2').className = "btn";
+ document.getElementById('btn3').className = "btn";
+ document.getElementById(id).classList.toggle("active");
+}
+</script>
+
 <div id="services-tab">
 <ul class="nav nav-tabs" role="tablist" aria-label="Versions"> 
   <li role="presentation" class="active">
-    <a href="#odata-v4" role="tab" aria-controls="odata-v4" data-toggle="tab">OData v4</a>
+    <button href="#odata-v4" role="tab" aria-controls="odata-v4"  class="btn active" onclick="activateTabsById('btn1')" id = "btn1" data-toggle="tab">OData v4</button>
   </li>
   <li role="presentation">
-    <a  href="#v3" role="tab" data-toggle="tab" aria-controls="v3" tabindex="-1">OData v3</a>
+    <button  href="#v3" role="tab" data-toggle="tab" aria-controls="v3" class="btn" onclick="activateTabsById('btn2')" id = "btn2" tabindex="-1">OData v3</button>
   </li>
   <li role="presentation">
-    <a href="#v2" role="tab" data-toggle="tab" aria-controls="v2" tabindex="-1">OData v2</a>
+    <button href="#v2" role="tab" data-toggle="tab" aria-controls="v2" class="btn" onclick="activateTabsById('btn3')" id = "btn3" tabindex="-1">OData v2</button>
   </li>
 </ul>
 


### PR DESCRIPTION
This PR corrects the Tabs to appear as should under high contrast

Please see
https://identitydivision.visualstudio.com/OData/_workitems/edit/1366629

Note: User credentials should NOT be included in the bug.
Repro Steps:
Hit the URL https://www.odata.org/ and login with appropriate credentials to open Odata website
Tab till 'Developers' link and press enter
Tab till 'Reference Services' option and press enter
Verify all the controls in the "Odata V4" are accessible and Switch to high contrast theme and verify the issue.
Actual Result:
Tab button control is not adapting high contrast theme under Reference Services-Odata V4 blade.

Expected Result:
Tab button control should adapt high contrast theme under Reference Services-Odata V4 blade.

 

Note: Same issue exists throughout the application for all tab controls.



The tabs currently, normal mode
![image](https://user-images.githubusercontent.com/41168603/120756692-3f7d5f00-c518-11eb-8412-decba470f07a.png)

Tabs after change 

![image](https://user-images.githubusercontent.com/41168603/120756646-2f657f80-c518-11eb-9d41-efbd545f8eb1.png)

Before in High contrast

![image](https://user-images.githubusercontent.com/41168603/120756822-6f2c6700-c518-11eb-869d-884211f2568f.png)

After in High contrast

![image](https://user-images.githubusercontent.com/41168603/120756877-7c495600-c518-11eb-9985-9ade7e5cf13d.png)


