### PR TITLE
Ensure that controls don't disappear in low resolution screens

### DIFF
--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -982,10 +982,10 @@ HTTP/1.1 204 No Content
 </div>
 <div class="col-1-12"></div>
 <div class="col-1-4" id="tutorial-contents">
-    <nav class="tutorial-sidebar affix" aria-label="Page Contents">
+    <nav class="tutorial-sidebar affix" aria-label="Page Contents" id="affix-navbar">
         <ul class="nav tutorial-sidenav">
             <li class="active">
-                <a href="#requestData">Requesting Data</a></p>
+                <p><a href="#requestData" class="sidenav-link">Requesting Data</a></p>
                 <ul class="nav">
                     <li><a href="#entitySet">Requesting Entity Collections</a></li>
                     <li><a href="#entityByID">Requesting an Individual Entity by ID</a></li>
@@ -994,7 +994,7 @@ HTTP/1.1 204 No Content
                 </ul>
             </li>
             <li>
-                <a href="#queryData">Querying Data</a></p>
+                <p><a href="#queryData" class="sidenav-link">Querying Data</a></p>
                 <ul class="nav">
                     <li><a href="#filter">System Query Option $filter</a></li>
                     <li><a href="#orderby">System Query Option $orderby</a></li>
@@ -1007,7 +1007,7 @@ HTTP/1.1 204 No Content
                 </ul>
             </li>
             <li>
-                <a href="#modifyData">Data Modification</a></p>
+                <p><a href="#modifyData" class="sidenav-link">Data Modification</a></p>
                 <ul class="nav">
                     <li><a href="#create">Create an Entity</a></li>
                     <li><a href="#delete">Delete an Entity</a></li>
@@ -1025,4 +1025,24 @@ HTTP/1.1 204 No Content
 <!--/body-->
 <script type="text/javascript">
     $(".page-header").css({"width":"66.66%"});
+    const storeScroll = () => {
+        document.documentElement.dataset.scroll = window.scrollY;
+        var heightScrolled = window.scrollY;
+        var defaultHeight = 100;
+        if (heightScrolled < defaultHeight) {
+            $('#affix-navbar').removeClass("affix-top-30");
+          $('#affix-navbar').addClass("affix-top-50");
+            }
+        else{
+          $('#affix-navbar').removeClass("affix-top-50");
+          $('#affix-navbar').addClass("affix-top-30"); 
+            }
+    };
+
+    // Listen for new scroll events
+    document.addEventListener("scroll", storeScroll);
+
+    // Update scroll position for first time
+    storeScroll();
+    
 </script>

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -134,6 +134,8 @@ code {
     font-weight: 500;
     color: #bf3e11;
     padding: 4px 20px;
+    word-wrap:break-word;
+    overflow-wrap: break-word;
 }
 .tutorial-sidebar .nav>li>a:hover, .tutorial-sidebar .nav>li>a:focus {
     padding-left: 19px;
@@ -141,6 +143,8 @@ code {
     text-decoration: none;
     background-color: transparent;
     border-left: 1px solid #563d7c;
+    word-wrap:break-word;
+    overflow-wrap: break-word;
 }
 .tutorial-sidebar .nav>.active>a, .tutorial-sidebar .nav>.active:hover>a, .tutorial-sidebar .nav>.active:focus>a {
     padding-left: 18px;
@@ -148,6 +152,8 @@ code {
     color: #563d7c;
     background-color: transparent;
     border-left: 2px solid #563d7c;
+    word-wrap:break-word;
+    overflow-wrap: break-word;
 }
 .tutorial-sidebar .nav .nav {
     display: none;
@@ -159,6 +165,8 @@ code {
     padding-left: 30px;
     font-size: 14px;
     font-weight: 400;
+    word-wrap:break-word;
+    overflow-wrap: break-word;
 }
 .tutorial-sidebar .nav .nav>li>a:hover, .tutorial-sidebar .nav .nav>li>a:focus {
     padding-left: 29px;
@@ -168,7 +176,7 @@ code {
     padding-left: 28px;
 }
 .tutorial-sidebar.affix, .tutorial-sidebar.affix-bottom {
-    width: 213px;
+    word-wrap: break-word;
 }
 .tutorial-sidebar.affix {
     position: fixed;
@@ -190,7 +198,7 @@ code {
 	top: 50px;
 }
 
-@media (max-width: 991px) {
+@media (max-width: 767px) {
   .affix {
     position: static;
   	display: block;
@@ -199,7 +207,7 @@ code {
   }
 }
 
-@media (min-width:992px) {
+@media (min-width:768px) {
     .tutorial-sidebar .nav>.active>ul {
     display: block;
 	}
@@ -358,3 +366,11 @@ pre {
   color: white;
   text-decoration: underline;
 }
+
+.affix-top-50 {
+    top: 50%;
+  }
+
+.affix-top-30 {
+    top: 30%;
+  }


### PR DESCRIPTION
Follow up to https://github.com/OData/odataorg.github.io/pull/268

Some low resolution screens still have the controls disappearing. This fix removes the fixed width in the controls and then updates their positioning based on the page scrolling.