### PR TITLE
Fix color contrast on strong elements

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -382,3 +382,8 @@ pre {
   }
 }
 
+strong {
+  color: #000;
+  font-weight: bold;
+  font-size: 1.5rem;
+}


### PR DESCRIPTION
Strong elements have a muted color this fixes it and returns proper contrast to the items
Before
![image](https://user-images.githubusercontent.com/1511024/129323856-e168854e-ef77-4923-b885-66186f10fce4.png)

After
![image](https://user-images.githubusercontent.com/1511024/129324081-e72586ff-ae46-45b7-937d-faaf91f639e8.png)


