### PR TITLE
Use unique ID for navbar search input

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -88,7 +88,7 @@
 
                 <form class="navbar-form navbar-left" role="search">
                     <div class="form-group combobox combobox-list">
-                        <input id="search"
+                        <input id="main-search-input"
                                type="text"
                                aria-label="Search"
                                class="form-control st-default-search-input"

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -44,7 +44,7 @@
             });
         }
 
-        var search = $('#search');
+        var search = $('#main-search-input');
 
         var renderResults = function(ctx, data) {
             var results = [];
@@ -86,7 +86,7 @@
 
             search.attr('aria-expanded', true);
             var button = document.getElementById('cb1-button');
-            var cba = new ComboboxAutocomplete(document.getElementById('search'), button, document.getElementById('search-results'));
+            var cba = new ComboboxAutocomplete(document.getElementById('main-search-input'), button, document.getElementById('search-results'));
             cba.init();
             button.click();
         };


### PR DESCRIPTION
## Issue Description

The search input in the navbar has ID `search`. The same `search` ID is used for the `div` element that contains the `System Query Option $search` section in the ["Basic Tutorial" page](https://www.odata.org/getting-started/basic-tutorial/#search).

Since this navbar is included in all pages, this means that the "Basic Tutorial" page has a duplicated id (`search`). This causes issues in both accessibility and scripts that rely on the element's id. For example, clicking the "System Query Option $search" link on the "Basic Tutorial" page takes you to the navbar search input instead of the $search section of the tutorial.

[Here are more issues that can be caused by duplicate ids](https://accessibilityinsights.io/info-examples/web/duplicate-id-active/)

## Fix

I changed the id of the search input to `main-search-input` and updated relevant scripts. I opted to change the id of the input instead of the id of the page section because updating the id of the page section could potentially lead to broken links.