### PR TITLE
Change background color of menu list items when focused

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -344,7 +344,7 @@ pre {
   margin-right: auto;
 }
 
-.dropdown-menu li a:hover {
+.dropdown-menu li a:hover, .dropdown-menu li a:focus {
   background-color: #c34113;
 }
 


### PR DESCRIPTION
In #281, we fixed the `a:hover` background color. We need to do the same for `a:focus` since some users will be accessing the menu items by tabbing instead of hovering using a mouse.