### PR TITLE
Fix luminosity of search border when focused.

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -42,7 +42,7 @@
 	color: #000000 !important; 
 }
 .st-default-search-input:focus {
-  border-color: #3a98e3 !important;
+        border-color: #3a98e3 !important;
 }
 @media screen and (-ms-high-contrast: black-on-white) {
   .brand

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -41,6 +41,9 @@
 .st-default-search-input{
 	color: #000000 !important; 
 }
+.st-default-search-input:focus {
+  border-color: #3a98e3 !important;
+}
 @media screen and (-ms-high-contrast: black-on-white) {
   .brand
   {


### PR DESCRIPTION
Fixes Accessibility item 2110071

The search bar's luminosity has a 2.4:1 contrast ratio when focused, which is less than the recommended 3:1 (WCAG AA).

![image](https://user-images.githubusercontent.com/8460169/213992525-611aa362-cb15-4801-b9cd-d95665885651.png)

To address the issue, I changed the focus border color from `#66afe9` to `#3a98e3`. Not sure if it's required to go up to WCAG AAAA compliance for this case, but the issue only reported 3:1 ratio. The darker I made the border, the less appealing it looked.

![image](https://user-images.githubusercontent.com/8460169/213995383-1c4402c7-256a-4dd7-9734-00c38d713997.png)



**Before**

![image](https://user-images.githubusercontent.com/8460169/213994756-12fdcc39-d9ba-4dd0-998d-950388ba29cb.png)


**After**

![image](https://user-images.githubusercontent.com/8460169/213994634-651051a7-8eee-45cb-bbb3-fc2d7950b1da.png)

