### PR TITLE
Increase contrast in code syntax highlighting

### DIFF
--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -28,14 +28,14 @@
 .s { color: #ce3512 } /* Literal.String */
 .na { color: #006699; } /* Name.Attribute */
 .nb { color: #336666 } /* Name.Builtin */
-.nc { color: #00AA88; } /* Name.Class */
+.nc { color: #007961; } /* Name.Class */
 .no { color: #336600 } /* Name.Constant */
 .nd { color: #9999FF } /* Name.Decorator */
 .ni { color: #999999; } /* Name.Entity */
 .ne { color: #CC0000; } /* Name.Exception */
 .nf { color: #8700A8 } /* Name.Function */
 .nl { color: #9999FF } /* Name.Label */
-.nn { color: #00CCFF; } /* Name.Namespace */
+.nn { color: #007695; } /* Name.Namespace */
 .nt { color: #2f6f9f; } /* Name.Tag */
 .nv { color: #003333 } /* Name.Variable */
 .ow { color: #000000; } /* Operator.Word */


### PR DESCRIPTION
Fixes Accessibility Work Item: 2283560

Increase contrast ratio in syntax highlighting to improve legibility. My changes target namespaces and class names.

**Before**
![image](https://user-images.githubusercontent.com/8460169/214036330-e8d663df-5b5d-4f6c-be05-97c31bc2224d.png)

**After**

![image](https://user-images.githubusercontent.com/8460169/214036792-08477206-a5d7-49b6-86c8-50fbba93e08a.png)

