### PR TITLE
Add table caption and remove presentation role.

### DIFF
--- a/pages/ecosystem.html
+++ b/pages/ecosystem.html
@@ -21,7 +21,8 @@ permalink: /ecosystem/
 	OData producers are services that expose their data using the OData protocol. Below we have collected a list of key OData producers, which will continue to grow along with the OData ecosystem. You can use <a href="https://www.odata.org/libraries">OData SDK</a> to build your own OData producers. If you create or know of an OData producer not listed be sure to let us know via our new <a href="https://www.odata.org/contribution">contribution page</a>.
 
 	<a href="http://www.telerik.com/products/orm.aspx">Telerik OpenAccess ORM</a>In mid-2010 Telerik released a LINQ implementation that is simple to use and produces domain models very fast. Built on top of the enterprise-grade Telerik OpenAccess ORM the LINQ implementation allows you to easily build an OData feed via a few easy steps by using the OpenAccess Visual Designer and the Data Services Wizard. For more info, visit <a href="https://www.telerik.com/odata">www.telerik.com/odata</a>
-	<table class="table table-striped table-hover" role="presentation" aria-describedby="producers_header">
+	<table class="table table-striped table-hover" aria-describedby="producers_header">
+	<caption class="sr-only">Producers</caption>
 	<tbody>
 		{% assign producers = site.ecosys | where: "category", "producers" %}
 		{% for producer in producers %}
@@ -42,7 +43,8 @@ permalink: /ecosystem/
 	<div id="consumers" class="tab-pane">
 	<h2 id="consumers_header">Consumers</h2>
 	OData consumers are simply applications that consume data exposed using the OData protocol. OData consumers can vary greatly in sophistication, from something as simple as your web browser all the way through to a custom application that takes advantage of all the features of the OData Protocol. Below we have collected a list of key OData consumers, which will continue to grow along with the OData ecosystem. Simply pick a consumer from the list below and point it at one of the live services. If you create or know of an OData consumer not listed be sure to let us know via our new <a href="https://www.odata.org/contribution">contribution page</a>.
-	<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="consumers_header">
+	<table class="table table-striped table-condensed table-hover" aria-describedby="consumers_header">
+	<caption class="sr-only">Consumers</caption>
 	<tbody>
 		{% assign consumers = site.ecosys | where: "category", "consumers" %}
 		{% for consumer in consumers %}
@@ -62,7 +64,8 @@ permalink: /ecosystem/
 </div>
 <div id="liveservices" class="tab-pane">
 	<h2 id="liveservices_header">Live Services</h2>
-<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="liveservices_header">
+<table class="table table-striped table-condensed table-hover" aria-describedby="liveservices_header">
+<caption class="sr-only">Live Services</caption>
 <tbody>
 	{% assign liveservices = site.ecosys | where: "category", "liveservices" %}
 	{% for liveservice in liveservices %}
@@ -83,7 +86,8 @@ permalink: /ecosystem/
 <div id="sdk" class="tab-pane">
 <h2 id="sdk_header">OData SDK - Sample Code</h2>
 The OData SDK includes some sample code to show you how to do everything from create a general purpose OData Explorer to creating OData services and tests that verify that service is producing valid OData.
-<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="sdk_header">
+<table class="table table-striped table-condensed table-hover" aria-describedby="sdk_header">
+<caption class="sr-only">OData SDK Sample Code</caption>
 <tbody>
 	{% assign sdks = site.ecosys | where: "category", "sdk" %}
 	{% for sdk in sdks %}
@@ -108,7 +112,8 @@ The OData SDK includes some sample code to show you how to do everything from cr
 </div>
 <div id="tutorials" class="tab-pane">
 <h2 id="tutorials_header">Tutorials</h2>
-<table class="table table-striped table-condensed table-hover" role="presentation" aria-describedby="tutorials_header">
+<table class="table table-striped table-condensed table-hover" aria-describedby="tutorials_header">
+<caption class="sr-only">Tutorials</caption>
 <tbody>
 	{% assign tutorials = site.ecosys | where: "category", "tutorials" %}
 	{% for tutorial in tutorials %}


### PR DESCRIPTION
Fixes Accessibility Work Item: 2285453

The issue reported conflict from using the `presentation` role on an element with a global ARIA attribute:

![image](https://user-images.githubusercontent.com/8460169/214053406-b2540c86-7a61-4799-86ef-74fcc76780a5.png)

I addressed this by removing `role="presentation"` from all the tables on the page.

The issue also reported that the narrator did not announce the name of the table when entering the table. I'm not sure whether this is something that should happen by default, or if the original developers intended to achieve this using the `aria-describedby` attribute that's on all the tables on this page, but the narrator wasn't announcing the name. I eventually got the narrator to announce the name by adding `caption` to each table. Since I only wanted the caption to be read by screen readers, but not displayed on the page, I used the `.sr-only` class.