### PR TITLE
Remove keyboard focus from non-interactive code elements

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -179,6 +179,4 @@
         }        
     }
 
-    $('code').attr('tabindex',0);
-    $('pre').attr('tabindex',0);
 </script>


### PR DESCRIPTION
- Removed keyboard focus from non-interactive code elements and code block elements (addresses accessibility work items [2103702](https://identitydivision.visualstudio.com/OData/_workitems/edit/2103702) and [2115623](https://identitydivision.visualstudio.com/OData/_workitems/edit/2115623))

(Note: Setting the `tabindex` property to `0` on a given element ["means that the element should be focusable in sequential keyboard navigation, after any positive tabindex values."](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex))