### PR TITLE
Make tables accessible

### DIFF
--- a/pages/documentation/terminology.html
+++ b/pages/documentation/terminology.html
@@ -9,7 +9,7 @@ permalink: /documentation/odata-version-2-0/terminology/
 <a href="/documentation/" class="alert-link" title=""><span class="glyphicon glyphicon-arrow-right"></span> Go to OData Version 4.0</a></p>
 <h2 role="heading">Summary of References:</h2>
 <div>
-<table border="1" cellspacing="0" cellpadding="0" role="presentation" aria-label="Summary of References">
+<table border="1" cellspacing="0" cellpadding="0" aria-label="Summary of References">
     <thead>
         <tr>
             <th valign="top" width="151">Reference</th>

--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -24,7 +24,7 @@ permalink: /libraries/
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
-      <table class="table table-striped table-condensed table-hover reflows" role="presentation" aria-label=".NET Libraries">
+      <table class="table table-striped table-condensed table-hover reflows" aria-label=".NET Libraries">
         <thead>
         <tr>
           <th>Name</th>
@@ -63,7 +63,7 @@ permalink: /libraries/
     {% if library.name != "net" %}
 
     <div class="tab-pane" id="{{library.name}}" role="tabpanel" hidden>
-      <table class="table table-striped table-condensed table-hover reflows" role="presentation" aria-label="{{library.name}} Libraries">
+      <table class="table table-striped table-condensed table-hover reflows" aria-label="{{library.name}} Libraries">
         <thead>
         <tr>
           <th>Name</th>

--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -19,7 +19,7 @@ permalink: /odata-services/
 
 <div class="tab-content">
   <div id="odata-v4" tabindex="0" class="tab-pane active" role="tabpanel">
-    <table class="table table-striped table-condensed table-hover reflows" role="presentation" aria-label="OData v4 Reference Services">
+    <table class="table table-striped table-condensed table-hover reflows" aria-label="OData v4 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>
@@ -60,7 +60,7 @@ permalink: /odata-services/
     </table>
   </div>
   <div class="tab-pane" id="v3" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover" role="presentation" aria-label="OData v3 Reference Services">
+    <table class="table table-striped table-condensed table-hover" aria-label="OData v3 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>
@@ -80,7 +80,7 @@ permalink: /odata-services/
     </table>
   </div>
   <div class="tab-pane" id="v2" role="tabpanel" hidden>
-    <table class="table table-striped table-condensed table-hover" role="presentation" aria-label="OData v2 Reference Services">
+    <table class="table table-striped table-condensed table-hover" aria-label="OData v2 Reference Services">
       <tr>
         <th>Name</th>
         <th>Description</th>


### PR DESCRIPTION
Remove `role="presentation"` from `<table />`. This will make it possible for:
- The user to access the table by pressing `T`.
- The narrator to read the table label and the column names.