### PR TITLE
Add required child aria roles

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ layout: default
             <p class="text-center">An <b>open protocol</b> to allow the creation and consumption of <b>queryable</b> and <b>interoperable RESTful APIs</b> in a <b>simple</b> and <b>standard</b> way.</p>
         </div>
       </div>
-      <div class="item">
+      <div class="item" role="option">
         <img src="{{ '/assets/homepage_2.jpg' | prepend: site.baseurl | prepend: site.url}}" alt="Blog" style="opacity:1.0">
         <div class="carousel-caption jumbotron" style="background-color: rgba(255,255,255,0.5)">
             <h1 class="text-center bottom-margin">Recent Posts</h1>

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -471,18 +471,18 @@ OData-Version: 4.0
 <p class="text-justify bottom-margin">As the REST principles go, "Everything is a Resource". As a simple start, let's see how resources can be retrieved from the OData RESTful APIs. The sample service used is the TripPin service which simulates the service of an open trip management system. Our friend, Russell Whyte, who has formerly registered TripPin, would like to find out who are the other people in it.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link"  href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link"  href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link"  href="#csharp1" role="tab" id="csharpDrop1" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link"role="menu" aria-labelledby="csharpDrop1" id="csharpDrop1-contents">
 <li><a class="tab-link"  href="#csharpCodeGen1" tabindex="-1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aira-controls="csharpCodeGen1">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link"  href="#csharpSimpleOData1" tabindex="-1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aira-controls="csharpSimpleOData1">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http1">
@@ -578,18 +578,18 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <p class="text-justify bottom-margin">REST principles also say, that every resource is identified by a unique identifier. OData also enables defining key properties of a resource and retrieving it using the keys. In this step, Russell wants to find the information about himself by specifying his username as the key.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link" href="#http2" role="tab" aria-controls="http2" data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link" href="#http2" role="tab" aria-controls="http2" data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link" href="#csharp2" role="tab" id="csharpDrop2" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop2-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link" role="menu" aria-labelledby="csharpDrop1" id="csharpDrop2-contents">
 <li><a class="tab-link" href="#csharpCodeGen2" tabindex="-1" role="tab" id="csharpCodeGen2-tab" data-toggle="tab" aira-controls="csharpCodeGen2">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link" href="#csharpSimpleOData2" tabindex="-1" role="tab" id="csharpSimpleOData2-tab" data-toggle="tab" aira-controls="csharpSimpleOData2">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link" href="#olingo-js-2" role="tab" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link" href="#odatacpp-2" role="tab" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link" href="#nodejs-2" role="tab" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-2" role="tab" aria-controls="contribute-2" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-2" role="tab" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-2" role="tab" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-2" role="tab" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-2" role="tab" aria-controls="contribute-2" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http2">
@@ -686,18 +686,18 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <p class="text-justify bottom-margin">As an architecture that's built on top of the current features of the Web, RESTful APIs can also support query strings. For that, OData defines a series of system query options that can help you construct complicated queries for the resources you want. With the help of that, our friend Russell can find out the first 2 persons in the system who have registered at least one trip that costs more than 3000, and only display their first name and last name.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link" href="#http3" role="tab" aria-controls="http3" data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link" href="#http3" role="tab" aria-controls="http3" data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link" href="#csharp3" role="tab" id="csharpDrop3" role="tab" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop3-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link" role="menu" aria-labelledby="csharpDrop3" id="csharpDrop3-contents">
 <li><a class="tab-link" href="#csharpCodeGen3" tabindex="-1" role="tab" id="csharpCodeGen3-tab" data-toggle="tab" aira-controls="csharpCodeGen3">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link" href="#csharpSimpleOData3" tabindex="-1" role="tab" id="csharpSimpleOData3-tab" data-toggle="tab" aira-controls="csharpSimpleOData3">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link" href="#olingo-js-3" role="tab" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link" href="#odatacpp-3" role="tab" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link" href="#nodejs-3" role="tab" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-3" role="tab" aria-controls="contribute-3" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-3" role="tab" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-3" role="tab" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-3" role="tab" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-3" role="tab" aria-controls="contribute-3" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http3">
@@ -803,18 +803,18 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <p class="text-justify bottom-margin">REST principles require the using of simple and uniform interfaces. With that regard, OData clients can expect unified interfaces of the resources. The stateless transfer of representations in REST are carried out by using different HTTP methods in the requests. After having gone through the first 3 steps, Russell thinks the system is useful. He wants to add his best friend Lewis to the system. He finds out that all he needs to do is to send a POST request containing a JSON representation of Lewis' information to the same interface from which he requested the people information.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link" href="#http4" role="tab" aria-controls="http4"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link" href="#http4" role="tab" aria-controls="http4"  data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link" href="#csharp4" role="tab" id="csharpDrop4" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop4-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link" role="menu" aria-labelledby="csharpDrop4" id="csharpDrop4-contents">
 <li><a class="tab-link" href="#csharpCodeGen4" tabindex="-1" role="tab" id="csharpCodeGen4-tab" data-toggle="tab" aira-controls="csharpCodeGen4">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link" href="#csharpSimpleOData4" tabindex="-1" role="tab" id="csharpSimpleOData4-tab" data-toggle="tab" aira-controls="csharpSimpleOData4">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link" href="#olingo-js-4" role="tab" aria-controls="olingo-js-4" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link" href="#odatacpp-4" role="tab" aria-controls="odatacpp-4" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link" href="#nodejs-4" role="tab" aria-controls="nodejs-4" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-4" role="tab" aria-controls="contribute-4" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-4" role="tab" aria-controls="olingo-js-4" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-4" role="tab" aria-controls="odatacpp-4" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-4" role="tab" aria-controls="nodejs-4" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-4" role="tab" aria-controls="contribute-4" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http4">
@@ -1066,18 +1066,18 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <p class="text-justify bottom-margin">In RESTful APIs, resources are usually dependent with each other. For that, the concept of relationships in OData can be defined among resources to add flexibility and richness to the data model. For example, in the TripPin OData service, people are related to the trips that they've booked using the system. Knowing that, Russell would like to invite Lewis to his existing trip in the U.S. by relating that trip to Lewis.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link" href="#http5" role="tab" aria-controls="http5"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link" href="#http5" role="tab" aria-controls="http5"  data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link" href="#csharp5" role="tab" id="csharpDrop5" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop5-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link" role="menu" aria-labelledby="csharpDrop5" id="csharpDrop5-contents">
 <li><a class="tab-link" href="#csharpCodeGen5" tabindex="-1" role="tab" id="csharpCodeGen5-tab" data-toggle="tab" aira-controls="csharpCodeGen5">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link" href="#csharpSimpleOData5" tabindex="-1" role="tab" id="csharpSimpleOData5-tab" data-toggle="tab" aira-controls="csharpSimpleOData5">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link" href="#olingo-js-5" role="tab" aria-controls="olingo-js-5" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link" href="#odatacpp-5" role="tab" aria-controls="odatacpp-5" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link" href="#nodejs-5" role="tab" aria-controls="nodejs-5" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-5" role="tab" aria-controls="contribute-5" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-5" role="tab" aria-controls="olingo-js-5" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-5" role="tab" aria-controls="odatacpp-5" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-5" role="tab" aria-controls="nodejs-5" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-5" role="tab" aria-controls="contribute-5" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http5">
@@ -1234,18 +1234,18 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <p class="text-justify bottom-margin">In RESTful APIs, there can be some custom operations that contain complicated logic and can be frequently used. For that purpose, OData supports defining functions and actions to represent such operations. They are also resources themselves and can be bound to existing resources. After having explored the TripPin OData service, Russell finds out that the it has a function called GetInvolvedPeople from which he can find out the involved people of a specific trip. He invokes the function to find out who else other than him and Lewis goes to that trip in the U.S.</p>
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
-<li role="presentation" class="active"><a class="tab-link" href="#http6" role="tab" aria-controls="http6"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
+<li role="tab" class="active"><a class="tab-link" href="#http6" role="tab" aria-controls="http6"  data-toggle="tab">HTTP request</a></li>
+<li role="tab" class="dropdown">
 <a class="tab-link" href="#csharp6" role="tab" id="csharpDrop6" class="dropdown-toggle" data-toggle="dropdown" aria-controls="csharpDrop1-contents">C# &nbsp;<span class="caret"></span></a></p>
 <ul class="dropdown-menu tab-link" role="menu" aria-labelledby="csharpDrop6" id="csharpDrop6-contents">
 <li><a class="tab-link" href="#csharpCodeGen6" tabindex="-1" role="tab" id="csharpCodeGen6-tab" data-toggle="tab" aira-controls="csharpCodeGen6">OData v4 Client Code Generator</a></li>
 <li><a class="tab-link" href="#csharpSimpleOData6" tabindex="-1" role="tab" id="csharpSimpleOData6-tab" data-toggle="tab" aira-controls="csharpSimpleOData6">Simple.OData.Client</a></li>
 </ul>
 </li>
-<li role="presentation"><a class="tab-link" href="#olingo-js-6" role="tab" aria-controls="olingo-js-6" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link" href="#odatacpp-6" role="tab" aria-controls="odatacpp-6" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link" href="#nodejs-6" role="tab" aria-controls="nodejs-6" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-6" role="tab" aria-controls="contribute-6" data-toggle="tab">Contribute</a></li>
+<li role="tab"><a class="tab-link" href="#olingo-js-6" role="tab" aria-controls="olingo-js-6" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="tab"><a class="tab-link" href="#odatacpp-6" role="tab" aria-controls="odatacpp-6" data-toggle="tab">C++</a></li>
+<li role="tab"><a class="tab-link" href="#nodejs-6" role="tab" aria-controls="nodejs-6" data-toggle="tab">Node.js</a></li>
+<li role="tab"><a class="tab-link" href="#contribute-6" role="tab" aria-controls="contribute-6" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http6">


### PR DESCRIPTION
Address issue noted by Web Compliance Accessibility Insights by adding aria roles to children of elements with roles that require them (in this case, "tab" to "tablist" children and "option" to "listbox" children.)