### PR TITLE
Use Azure Service Principal for authentication in odata.org publishing to Azure Web App staging slot

### DIFF
--- a/.github/workflows/publish_to_staging_slot.yml
+++ b/.github/workflows/publish_to_staging_slot.yml
@@ -1,6 +1,6 @@
 # Docs for the Azure Web Apps Deploy action: https://github.com/Azure/webapps-deploy
 # More on GitHub Actions for Azure: https://github.com/Azure/actions
-# More on OpenID Connect: https://github.com/azure/login#github-action-for-azure-login
+# More on GitHub Action for Azure Login: https://github.com/azure/login#github-action-for-azure-login
 
 name: Publish OData org website to Azure Web App staging slot
 
@@ -12,10 +12,6 @@ on:
 
 jobs:
   build_and_deploy_job:
-    permissions: # Required when using OpenID Connect based federated identity credentials
-      id-token: write
-      contents: read
-    
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
 
@@ -31,12 +27,10 @@ jobs:
             -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
             jekyll/builder:stable /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
 
-      - name: Log in with Azure # Using OpenID Connect
+      - name: Log in with Azure # Using Azure Service Principal
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
           
       - name: Deploy to Azure Web App
         uses: azure/webapps-deploy@v2


### PR DESCRIPTION
Use Azure Service Principal  with a secret for authentication in odata.org publishing to Azure Web App staging slot