### PR TITLE
Add files only on prod to repo and template to generate sitemap

### DIFF
--- a/sitemap
+++ b/sitemap
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in site.ecosys -%}
+<url>
+<loc>{{ item.url | prepend: site.baseurl | prepend: site.url }}</loc>
+<lastmod>{{ item.date | date_to_xmlschema }}</lastmod>
+</url>
+{% endfor -%}
+{% for library in site.libraries -%}
+<url>
+<loc>{{ library.url | prepend: site.baseurl | prepend: site.url }}</loc>
+</url>
+{% endfor -%}
+{% for post in site.posts -%}
+<url>
+<loc>{{ post.url | prepend: site.baseurl | prepend: site.url }}</loc>
+<lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+</url>
+{% endfor -%}
+{% for page in site.pages -%}
+{% unless page.layout == nil -%}
+<url>
+<loc>{{ page.url | prepend: site.baseurl | prepend: site.url }}</loc>
+</url>
+{% endunless -%}
+{% endfor -%}
+</urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,30 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{% for item in site.ecosys -%}
+<url>
+<loc>{{ item.url | prepend: site.baseurl | prepend: site.url }}</loc>
+<lastmod>{{ item.date | date_to_xmlschema }}</lastmod>
+</url>
+{% endfor -%}
+{% for library in site.libraries -%}
+<url>
+<loc>{{ library.url | prepend: site.baseurl | prepend: site.url }}</loc>
+</url>
+{% endfor -%}
+{% for post in site.posts -%}
+<url>
+<loc>{{ post.url | prepend: site.baseurl | prepend: site.url }}</loc>
+<lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+</url>
+{% endfor -%}
+{% for page in site.pages -%}
+{% unless page.layout == nil -%}
+<url>
+<loc>{{ page.url | prepend: site.baseurl | prepend: site.url }}</loc>
+</url>
+{% endunless -%}
+{% endfor -%}
+</urlset>

--- a/web.config
+++ b/web.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <httpProtocol>
+      <customHeaders>
+        <add name="Arr-Disable-Session-Affinity" value="true" />
+      </customHeaders>
+    </httpProtocol>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Since GitHub actions ZipDeploy deployment method DOES NOT preserve any files on the target directory if they're not in the package being deployed, I identified files present in prod (most likely pushed directly) but not in the GitHub repository and added them to the repository so they'll get packaged and published during deployment.

In addition, since a sitemap.xml file is present on prod and a Jekyll template for generating that file didn't exist in the repo, I added such a template that generates both _sitemap_ and _sitemap.xml_.
I wouldn't say I understand whether or why both are needed but I noticed that _feed_ and _feed.xml_ as well as _blog/feed_ and _blog/feed.xml_ that do something similar also exist in pairs.

**Note: You can run `jekyll build` locally to see the sitemap file that is generated**