### PR TITLE
Apply trigger and branch restrictions to workflows

### DIFF
--- a/.github/workflows/publish_to_production_slot.yml
+++ b/.github/workflows/publish_to_production_slot.yml
@@ -5,14 +5,11 @@
 name: Publish OData org website to Azure Web App production slot
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch: # Makes it possible to trigger workflow manually
 
 jobs:
   publish:
-    if: github.repository_owner == 'OData' && github.event_name == 'workflow_dispatch'
+    if: github.repository_owner == 'OData' && github.ref == 'refs/heads/master' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish_to_staging_slot.yml
+++ b/.github/workflows/publish_to_staging_slot.yml
@@ -5,9 +5,6 @@
 name: Publish OData org website to Azure Web App staging slot
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch: # Makes it possible to trigger workflow manually
 
 jobs:


### PR DESCRIPTION
Apply trigger and branch restrictions to workflows
- Production and staging workflows can only be triggered manually
- Production workflow restricts deployment branch to master