### PR TITLE
Request to Add new .NET library for MongoDB

### DIFF
--- a/_libraries/MongoDB-ASP-NET-Core-OData.md
+++ b/_libraries/MongoDB-ASP-NET-Core-OData.md
@@ -1,0 +1,11 @@
+---
+category: net
+name: MongoDB ASP.NET Core OData
+link: https://github.com/mongodb/mongo-aspnetcore-odata?tab=readme-ov-file
+version: V4
+object: Server
+downloads:
+  - source: nugetgallery
+    link: https://www.nuget.org/packages/MongoDB.AspNetCore.OData/
+---
+You can use OData with MongoDB in your ASP.NET Core applications by leveraging the MongoDB.OData extension which allows you to create your REST APIs for CRUD operations with MongoDB. 


### PR DESCRIPTION
The MongoDB OData extension for .NET is built on top of the MongoDB C# Driver. It allows developers intending to use OData to power their REST APIs with MongoDB quickly and seamlessly.