### PR TITLE
Update color contrast for the Nav tabs and table elements to 4.5

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -421,3 +421,16 @@ td {
     white-space: nowrap;
     width: 1px;
 }
+
+.nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus{
+  border-color: #737373eb;
+  border-bottom-color: transparent;
+}
+
+.table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td,  .page-header, .nav-tabs {
+  border-bottom-color: #737373eb;
+}
+
+.table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
+  border-top-color: #737373eb;
+}

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -423,14 +423,14 @@ td {
 }
 
 .nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus{
-  border-color: #737373eb;
+  border-color: #737373;
   border-bottom-color: transparent;
 }
 
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td,  .page-header, .nav-tabs {
-  border-bottom-color: #737373eb;
+  border-bottom-color: #737373;
 }
 
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
-  border-top-color: #737373eb;
+  border-top-color: #737373;
 }

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -425,6 +425,7 @@ td {
 .nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus{
   border-color: #737373;
   border-bottom-color: transparent;
+  border-width: 2px;
 }
 
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td,  .page-header, .nav-tabs {


### PR DESCRIPTION
Fixes contrast to acceptable levels for graphical elements.

Before
![image](https://github.com/user-attachments/assets/d29ba90d-c49e-4663-97be-9e2bda44dd33)

After
![image](https://github.com/user-attachments/assets/86d1e358-c451-4d17-b0a5-3e917fa544fb)

https://webaim.org/resources/contrastchecker/?fcolor=737373&bcolor=FFFFFF
