### PR TITLE
Fix issues with sidebar sub-links not visible when zoom in to 200% and above

### DIFF
--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -751,37 +751,37 @@ permalink: /getting-started/advanced-tutorial/
 </div>
 
 <script type="text/javascript">
-   $(".page-header").css({"width":"66.66%"});
-   const storeScroll = () => {
-       document.documentElement.dataset.scroll = window.scrollY;
-       var heightScrolled = window.scrollY;
-       var defaultHeight = 100;
-       if (heightScrolled < defaultHeight) {
-           $('#affix-navbar').removeClass("affix-top-30");
-         $('#affix-navbar').addClass("affix-top-50");
-           }
-       else{
-         $('#affix-navbar').removeClass("affix-top-50");
-         $('#affix-navbar').addClass("affix-top-30"); 
-           }
-   };
+   $(".page-header").css({ "width": "66.66%" });
+      const storeScroll = () => {
+         document.documentElement.dataset.scroll = window.scrollY;
+         var heightScrolled = window.scrollY;
+         var defaultHeight = 100;
+         if (heightScrolled < defaultHeight) {
+            $('#affix-navbar').removeClass("affix-top-30");
+            $('#affix-navbar').addClass("affix-top-50");
+         }
+         else {
+            $('#affix-navbar').removeClass("affix-top-50");
+            $('#affix-navbar').addClass("affix-top-30");
+         }
+      };
 
-   // Listen for new scroll events
-   document.addEventListener("scroll", storeScroll);
+      // Listen for new scroll events
+      document.addEventListener("scroll", storeScroll);
 
-   // Update scroll position for first time
-   storeScroll();
+      // Update scroll position for first time
+      storeScroll();
 
-   $(document).ready(function() {
-       $('.tutorial-sidebar').affix('checkPosition');
+      $(document).ready(function () {
+         $('.tutorial-sidebar').affix('checkPosition');
 
-       // Add click event listener to the sidebar links
-       $('.sidenav-link').on('click', function(e) {
-           // Remove 'active' class from all sidebar nav items
-           $(".sidebar-nav-item").removeClass('active');
-           // Add 'active' class to the parent of the clicked link's parent
-           $(this).parent().parent().addClass('active');
-       });
-   });
+         // Add click event listener to the sidebar links
+         $('.sidenav-link').on('click', function (e) {
+            // Remove 'active' class from all sidebar nav items
+            $(".sidebar-nav-item").removeClass('active');
+            // Add 'active' class to the parent of the clicked link's parent
+            $(this).parent().parent().addClass('active');
+         });
+      });
    
 </script>

--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -705,7 +705,7 @@ permalink: /getting-started/advanced-tutorial/
    <div class="col-1-4" style="float:right">
       <nav class="tutorial-sidebar" aria-label="Page Contents">
          <ul class="nav tutorial-sidenav" data-spy="affix">
-            <li class="active">
+            <li class="sidebar-nav-item active">
                <a href="#singleton">Singleton</a>
                <ul class="nav">
                   <li><a href="#querySingleton">Requesting Singleton</a></li>
@@ -713,7 +713,7 @@ permalink: /getting-started/advanced-tutorial/
                   <li><a href="#updateSingleton">Update Singleton</a></li>
                </ul>
             </li>
-            <li>
+            <li class="sidebar-nav-item">
                <a href="#derived">Derived Entity Type</a>
                <ul class="nav">
                   <li><a href="#requestDerivedEntitySet">Requesting a Derived Entity Collection</a></li>
@@ -724,7 +724,7 @@ permalink: /getting-started/advanced-tutorial/
                   <li><a href="#deleteDerived">Delete a Derived Entity</a></li>
                </ul>
             </li>
-            <li>
+            <li class="sidebar-nav-item">
                <a href="#containment">Containment Navigation Property</a>
                <ul class="nav">
                   <li><a href="#queryContained">Requesting a Contained Entity Set</a></li>
@@ -734,7 +734,7 @@ permalink: /getting-started/advanced-tutorial/
                   <li><a href="#deleteContainment">Delete a Contained Entity</a></li>
                </ul>
             </li>
-            <li>
+            <li class="sidebar-nav-item">
                <a href="#openType">Open Type</a>
                <ul class="nav">
                   <li><a href="#openEntity">Open Entity Type</a></li>
@@ -749,3 +749,39 @@ permalink: /getting-started/advanced-tutorial/
    </div>
    <div class="col-1-12"></div>
 </div>
+
+<script type="text/javascript">
+   $(".page-header").css({"width":"66.66%"});
+   const storeScroll = () => {
+       document.documentElement.dataset.scroll = window.scrollY;
+       var heightScrolled = window.scrollY;
+       var defaultHeight = 100;
+       if (heightScrolled < defaultHeight) {
+           $('#affix-navbar').removeClass("affix-top-30");
+         $('#affix-navbar').addClass("affix-top-50");
+           }
+       else{
+         $('#affix-navbar').removeClass("affix-top-50");
+         $('#affix-navbar').addClass("affix-top-30"); 
+           }
+   };
+
+   // Listen for new scroll events
+   document.addEventListener("scroll", storeScroll);
+
+   // Update scroll position for first time
+   storeScroll();
+
+   $(document).ready(function() {
+       $('.tutorial-sidebar').affix('checkPosition');
+
+       // Add click event listener to the sidebar links
+       $('.sidenav-link').on('click', function(e) {
+           // Remove 'active' class from all sidebar nav items
+           $(".sidebar-nav-item").removeClass('active');
+           // Add 'active' class to the parent of the clicked link's parent
+           $(this).parent().parent().addClass('active');
+       });
+   });
+   
+</script>

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -983,7 +983,7 @@ HTTP/1.1 204 No Content
 <div class="col-1-12"></div>
 <div class="col-1-4" id="tutorial-contents">
     <nav class="tutorial-sidebar affix" aria-label="Page Contents" id="affix-navbar">
-        <ul class="nav tutorial-sidenav">
+        <ul class="nav tutorial-sidenav" data-spy="affix">
             <li class="sidebar-nav-item active">
                 <p><a href="#requestData" class="sidenav-link">Requesting Data</a></p>
                 <ul class="nav">

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -1024,37 +1024,37 @@ HTTP/1.1 204 No Content
 
 <!--/body-->
 <script type="text/javascript">
-    $(".page-header").css({"width":"66.66%"});
-    const storeScroll = () => {
-        document.documentElement.dataset.scroll = window.scrollY;
-        var heightScrolled = window.scrollY;
-        var defaultHeight = 100;
-        if (heightScrolled < defaultHeight) {
-            $('#affix-navbar').removeClass("affix-top-30");
-          $('#affix-navbar').addClass("affix-top-50");
+    $(".page-header").css({ "width": "66.66%" });
+        const storeScroll = () => {
+            document.documentElement.dataset.scroll = window.scrollY;
+            var heightScrolled = window.scrollY;
+            var defaultHeight = 100;
+            if (heightScrolled < defaultHeight) {
+                $('#affix-navbar').removeClass("affix-top-30");
+                $('#affix-navbar').addClass("affix-top-50");
             }
-        else{
-          $('#affix-navbar').removeClass("affix-top-50");
-          $('#affix-navbar').addClass("affix-top-30"); 
+            else {
+                $('#affix-navbar').removeClass("affix-top-50");
+                $('#affix-navbar').addClass("affix-top-30");
             }
-    };
+        };
 
-    // Listen for new scroll events
-    document.addEventListener("scroll", storeScroll);
+        // Listen for new scroll events
+        document.addEventListener("scroll", storeScroll);
 
-    // Update scroll position for first time
-    storeScroll();
+        // Update scroll position for first time
+        storeScroll();
 
-    $(document).ready(function() {
-        $('.tutorial-sidebar').affix('checkPosition');
+        $(document).ready(function () {
+            $('.tutorial-sidebar').affix('checkPosition');
 
-        // Add click event listener to the sidebar links
-        $('.sidenav-link').on('click', function(e) {
-            // Remove 'active' class from all sidebar nav items
-            $(".sidebar-nav-item").removeClass('active');
-            // Add 'active' class to the parent of the clicked link's parent
-            $(this).parent().parent().addClass('active');
+            // Add click event listener to the sidebar links
+            $('.sidenav-link').on('click', function (e) {
+                // Remove 'active' class from all sidebar nav items
+                $(".sidebar-nav-item").removeClass('active');
+                // Add 'active' class to the parent of the clicked link's parent
+                $(this).parent().parent().addClass('active');
+            });
         });
-    });
     
 </script>

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -984,7 +984,7 @@ HTTP/1.1 204 No Content
 <div class="col-1-4" id="tutorial-contents">
     <nav class="tutorial-sidebar affix" aria-label="Page Contents" id="affix-navbar">
         <ul class="nav tutorial-sidenav">
-            <li class="active">
+            <li class="sidebar-nav-item active">
                 <p><a href="#requestData" class="sidenav-link">Requesting Data</a></p>
                 <ul class="nav">
                     <li><a href="#entitySet">Requesting Entity Collections</a></li>
@@ -993,7 +993,7 @@ HTTP/1.1 204 No Content
                     <li><a href="#propertyVal">Requesting an Individual Property Raw Value</a></li>
                 </ul>
             </li>
-            <li>
+            <li class="sidebar-nav-item">
                 <p><a href="#queryData" class="sidenav-link">Querying Data</a></p>
                 <ul class="nav">
                     <li><a href="#filter">System Query Option $filter</a></li>
@@ -1006,7 +1006,7 @@ HTTP/1.1 204 No Content
                     <li><a href="#lambda">Lambda Operators</a></li>
                 </ul>
             </li>
-            <li>
+            <li class="sidebar-nav-item">
                 <p><a href="#modifyData" class="sidenav-link">Data Modification</a></p>
                 <ul class="nav">
                     <li><a href="#create">Create an Entity</a></li>
@@ -1044,5 +1044,17 @@ HTTP/1.1 204 No Content
 
     // Update scroll position for first time
     storeScroll();
+
+    $(document).ready(function() {
+        $('.tutorial-sidebar').affix('checkPosition');
+
+        // Add click event listener to the sidebar links
+        $('.sidenav-link').on('click', function(e) {
+            // Remove 'active' class from all sidebar nav items
+            $(".sidebar-nav-item").removeClass('active');
+            // Add 'active' class to the parent of the clicked link's parent
+            $(this).parent().parent().addClass('active');
+        });
+    });
     
 </script>

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -211,6 +211,10 @@ code {
 	top: 50px;
 }
 
+.tutorial-sidebar .nav > .active > ul {
+  display: block;
+}
+
 @media (max-width: 767px) {
   .affix {
     position: static;
@@ -218,12 +222,6 @@ code {
   	float:right;
     top: 50%;
   }
-}
-
-@media (min-width:768px) {
-    .tutorial-sidebar .nav>.active>ul {
-    display: block;
-	}
 }
 
 /* URL styling */


### PR DESCRIPTION
At 200% Resize, Sub links present in right side of the Query Data page are getting hidden.

This change moved the CSS rule for `.tutorial-sidebar .nav>.active>ul` out of the media query and applied it directly. This means that the `display: block;` style will now apply to all screen sizes, not just those with a minimum width of `768px`.

## basic-tutorial
https://www.odata.org/getting-started/basic-tutorial/

**Before:**
![image](https://github.com/user-attachments/assets/50d7c81c-7bbf-4f31-a06e-9e810d6570ed)

**After:**
![image](https://github.com/user-attachments/assets/8fd799f3-cd7f-4bd6-9837-8c7d58aa1cbf)

## advanced-tutorial
https://www.odata.org/getting-started/advanced-tutorial/

**Before:**
![image](https://github.com/user-attachments/assets/962e8cc6-79ba-4f37-9e5a-a00f798c70f0)

**After:**
![image](https://github.com/user-attachments/assets/99202179-6ee8-4235-b103-ca1a4d931cfa)