### PR TITLE
Added SAP CAP as a oData server library for java and Nodejs

### DIFF
--- a/_libraries/capJava.md
+++ b/_libraries/capJava.md
@@ -1,0 +1,11 @@
+---
+category: java
+name: SAP CAP
+link: https://cap.cloud.sap/
+version: V4
+object:  Server
+downloads:
+  - source: SAP CAP Java
+  - link: https://cap.cloud.sap/docs/java/getting-started
+---
+SAP Cloud Application Programming Model (CAP) is a framework of languages, libraries, and tools for building enterprise-grade services and applications. The CAP Java SDK comes with an OData V4 protocol adapter, but it's openly designed.

--- a/_libraries/capjs.md
+++ b/_libraries/capjs.md
@@ -1,0 +1,11 @@
+---
+category: javascript
+name: SAP CAP
+link: https://cap.cloud.sap/
+version: V4
+object:  Server
+downloads:
+  - source: SAP CAP
+  - link: https://cap.cloud.sap/docs/get-started/#setup
+---
+SAP Cloud Application Programming Model (CAP) is a framework of languages, libraries, and tools for building enterprise-grade services and applications. With SAP CAP for NodeJS you can create a full-fledged REST, or OData, or GraphQL application. 


### PR DESCRIPTION
Hello,
I have added 2 new entries under libraries for java and nodejs. The library is called SAP CAP, and it's a framework offered by SAP used to develop restful APIs in different protocols, mainly oData V4. SAP CAP can be developed using CDS (a language developed by SAP used to define mainly models, entities and services) and NodeJS or CDS and Java.

Thanks