### PR TITLE
Use Text instead of image with text

### DIFF
--- a/pages/documentation/overview.html
+++ b/pages/documentation/overview.html
@@ -47,8 +47,24 @@ permalink: /documentation/odata-version-2-0/overview/
 <p>A full list of terms used by the Open Data Protocol is available on the <a title="Terminology" href="../terminology">[OData: Terms]</a> page.</p>
 <h2>1. Relationship to Other Protocols</h2>
 <p>As shown in Figure 1, OData builds on the conventions defined in the <a href="https://tools.ietf.org/html/rfc5023"> Atom Publishing Protocol (AtomPub)</a> and applies additional Web technologies such as <a href="https://tools.ietf.org/html/rfc2616">HTTP</a> and <a href="https://tools.ietf.org/html/rfc4627"> JavaScript Object Notation (JSON)</a> to create a protocol that enables access to information from a variety of applications, services, and stores.</p>
-<div>
-<a href="/assets/RelToOtherProtocols.png"><img src="/assets/RelToOtherProtocols.png" alt="RelToOtherProtocols" width="345" height="143" class="aligncenter size-full wp-image-1841" /></a>
+<div class="other-protocols-container">
+    <table class="other-protocols-table" border="1" cellspacing="0" cellpadding="0" aria-label="OData Protocol Relationship with other Protocols">
+<tbody>
+    <tr>
+        <th colspan="6">Open Data Protocol (v2.0)</th>
+    </tr>
+    <tr>
+        <th colspan="6">Open Data Protocol (v1.0)</th>
+    </tr>
+    <tr>
+        <td class="other-protocols-item">AtomPub [RFC5023]</td>
+        <td class="other-protocols-item">JSON [RFC4627]</td>
+        <td class="other-protocols-item">XML etc</td>
+        <td class="other-protocols-item">HTTP(s) [RFC2616]</td>
+        <td class="other-protocols-item">TCP [RFC793]</td>
+    </tr>
+</tbody>    
+</table>
 </div>
 <h2>2. OData Basics</h2>
 <p>At the core of OData are <strong>feeds</strong>, which are <strong>Collections</strong> of typed <strong>Entries</strong>. Each entry represents a structured record with a key that has a list of <strong>Properties</strong> of primitive or complex types. Entries can be part of a type hierarchy and may have related entries and related feeds through <strong>Links</strong>. For example the following URI represents a feed of Product entries: <a href="https://services.odata.org/OData/OData.svc/Products"> https://services.odata.org/OData/OData.svc/Products</a>.</p>

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -433,3 +433,28 @@ td {
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
   border-top-color: #737373;
 }
+
+.other-protocols-container {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.other-protocols-table {
+  width: 60%;
+  border-collapse: collapse;
+  margin-bottom: 5px;
+}
+
+.other-protocols-table th, .other-protocols-table td {
+  border: 1px solid black;
+  padding: 5px;
+}
+
+.other-protocols-table th {
+  text-align: center;
+}
+
+.other-protocols-item {
+  background-color: #f2f2f2;
+}


### PR DESCRIPTION
## Description

This PR removes image and replaces it with HTML table with data.

## Before (`using image with text`):
![image](https://github.com/user-attachments/assets/4002dc92-8d35-4d7a-a146-d968deff51c1)

## After (`using table with the texts as table headers and table data`):
![image](https://github.com/user-attachments/assets/e260c2c5-88b2-4d74-8d3f-a1749586db23)
