### PR TITLE
Fix images not visible at 400%

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -433,3 +433,19 @@ td {
 .table>thead>tr>th, .table>tbody>tr>th, .table>tfoot>tr>th, .table>thead>tr>td, .table>tbody>tr>td, .table>tfoot>tr>td {
   border-top-color: #737373;
 }
+
+img {
+  max-width: 100%; /* Ensures images scale with the container */
+  height: auto; /* Maintains aspect ratio */
+  display: block; /* Prevents inline spacing issues */
+  margin: 0 auto; /* Centers images */
+  image-rendering: crisp-edges;
+  image-rendering: -webkit-optimize-contrast;
+}
+
+@media (max-width: 768px) {
+  img {
+    width: 100%; /* Ensures images fit smaller screens */
+    height: auto;
+  }
+}

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -434,18 +434,18 @@ td {
   border-top-color: #737373;
 }
 
-img {
-  max-width: 100%; /* Ensures images scale with the container */
-  height: auto; /* Maintains aspect ratio */
-  display: block; /* Prevents inline spacing issues */
-  margin: 0 auto; /* Centers images */
-  image-rendering: crisp-edges;
-  image-rendering: -webkit-optimize-contrast;
+.post-content>p> img {
+    max-width: 100%; /* Ensures images scale with the container */
+    height: auto; /* Maintains aspect ratio */
+    display: block; /* Prevents inline spacing issues */
+    margin: 0 auto; /* Centers images */
+    image-rendering: crisp-edges;
+    image-rendering: -webkit-optimize-contrast;
 }
 
 @media (max-width: 768px) {
-  img {
-    width: 100%; /* Ensures images fit smaller screens */
-    height: auto;
-  }
+    .post-content>p> img {
+        width: 100%; /* Ensures images fit smaller screens */
+        height: auto;
+    }
 }


### PR DESCRIPTION
Issue: Fix images not visible at 400% zoom

Summary: This PR addresses accessibility issues related to images not being properly visible when zoomed to 400% reflow mode. The problem was identified in the OData project, specifically in the context of the "Webinar on Salesforce Connect External Object Reporting" blog. The images below this blog were not displaying correctly when the reflow settings were applied.

Details:

Ensured images scale with the container by setting max-width: 100% and height: auto.
Prevented inline spacing issues by setting display: block.
Centered images within their container using margin: 0 auto.
Improved rendering quality of images with image-rendering: crisp-edges and image-rendering: -webkit-optimize-contrast.
Added a media query for screens with a maximum width of 768px to ensure images fit smaller screens by setting their width to 100% and maintaining their aspect ratio.

Before:

![image](https://github.com/user-attachments/assets/a7eff067-7619-4012-8d1e-65b7b423bd04)

After:

![Screenshot 2025-02-05 100044](https://github.com/user-attachments/assets/8174314e-bb7d-4440-b11c-a47efc2a1533)

![image](https://github.com/user-attachments/assets/f0a841e9-1cd2-47ac-a8ed-7d18876ef24c)





