### PR TITLE
Fix tab controls so text is visible in high contrast

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -382,9 +382,9 @@ pre {
   }
 
 @media screen and (-ms-high-contrast: active) {
-     .tab-link { 
-      -ms-high-contrast-adjust:none;
-      color: white;
+  .tab-link {
+    -ms-high-contrast-adjust:none;
+    color: LinkText;
   }
 }
 


### PR DESCRIPTION
Fixed by replacing `color:white` with `color:LinkText` for `-ms-high-contrast` style for tab link. This should ensure that the system colors are adapted for the links in high contrast:

Aquatic:
![odataorg-aquatic-theme](https://github.com/user-attachments/assets/93d5c0f2-457c-43b7-b6c2-4edff17c9f1f)

Desert:
![odataorg-desert-theme](https://github.com/user-attachments/assets/91b0573d-1286-4155-aea8-eafc960b9e9a)
