### PR TITLE
Update and fix tab behavior on tab navigation.

### DIFF
--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -472,12 +472,12 @@ OData-Version: 4.0
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link"  href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation"><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1">C# OData v4 Client Code Generator</a></li>
-<li role="presentation"><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1">C# Simple.OData.Client</a></li>
-<li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
-<li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
+<li role="presentation"><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1" aria-label="C sharp OData v4 Client Code Generator">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1" aria-label="C sharp Simple.OData.Client">C# Simple.OData.Client</a></li>
+<li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab" aria-label="Olingo JavaScript client">Olingo JavaScript client</a></li>
+<li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab" aria-label="C++">C++</a></li>
+<li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab" aria-label="Node.js">Node.js</a></li>
+<li role="presentation"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab" aria-label="Contribute">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http1">

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -472,14 +472,8 @@ OData-Version: 4.0
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link"  href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle"  href="#csharp1" role="tab" id="csharpDrop1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop1-contents">C# &nbsp;<span
-            class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop1-contents">
-<li><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation"><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1">C# Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab">Node.js</a></li>
@@ -494,14 +488,14 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-collection-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen1" aria-labelledby="csharpCodeGen1-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen1">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/TripPinServiceRW/"));
 var people = context.People.Execute();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData1" aria-labelledby="csharpSimpleOData1-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData1">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -580,14 +574,8 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link" href="#http2" role="tab" aria-controls="http2" data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle" href="#csharp2" role="tab" id="csharpDrop2" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop2-contents">C# &nbsp;<span
-            class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop2-contents">
-<li><a class="tab-link" href="#csharpCodeGen2" role="tab" id="csharpCodeGen2-tab" data-toggle="tab" aria-controls="csharpCodeGen2">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link" href="#csharpSimpleOData2" role="tab" id="csharpSimpleOData2-tab" data-toggle="tab" aria-controls="csharpSimpleOData2">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation" ><a class="tab-link" href="#csharpCodeGen2" role="tab" id="csharpCodeGen2-tab" data-toggle="tab" aria-controls="csharpCodeGen2">C# OData v4 Client Code Generator</a></li>
+<li role="presentation" ><a class="tab-link" href="#csharpSimpleOData2" role="tab" id="csharpSimpleOData2-tab" data-toggle="tab" aria-controls="csharpSimpleOData2">C# Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link" href="#olingo-js-2" role="tab" aria-controls="olingo-js-2" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link" href="#odatacpp-2" role="tab" aria-controls="odatacpp-2" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link" href="#nodejs-2" role="tab" aria-controls="nodejs-2" data-toggle="tab">Node.js</a></li>
@@ -602,14 +590,14 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-individual-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen2" aria-labelledby="csharpCodeGen2-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen2">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var person = context.People.ByKey(userName: "russellwhyte").GetValue();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData2" aria-labelledby="csharpSimpleOData2-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData2" aria-labelledby="csharpSimpleOData2-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -689,14 +677,8 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link" href="#http3" role="tab" aria-controls="http3" data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle" href="#csharp3" role="tab" id="csharpDrop3" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop3-contents">C#
-          &nbsp;<span class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop3-contents">
-<li><a class="tab-link" href="#csharpCodeGen3" role="tab" id="csharpCodeGen3-tab" data-toggle="tab" aria-controls="csharpCodeGen3">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link" href="#csharpSimpleOData3" role="tab" id="csharpSimpleOData3-tab" data-toggle="tab" aria-controls="csharpSimpleOData3">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation"><a class="tab-link" href="#csharpCodeGen3" role="tab" id="csharpCodeGen3-tab" data-toggle="tab" aria-controls="csharpCodeGen3">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link" href="#csharpSimpleOData3" role="tab" id="csharpSimpleOData3-tab" data-toggle="tab" aria-controls="csharpSimpleOData3">C# Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link" href="#olingo-js-3" role="tab" aria-controls="olingo-js-3" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link" href="#odatacpp-3" role="tab" aria-controls="odatacpp-3" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link" href="#nodejs-3" role="tab" aria-controls="nodejs-3" data-toggle="tab">Node.js</a></li>
@@ -711,14 +693,14 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-query-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen3" aria-labelledby="csharpCodeGen3-tab">
+<div role="tabpanel" class="tab-pane " id="csharpCodeGen3" aria-labelledby="csharpCodeGen3-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var people = context.People.Where(c => c.Trips.Any(d => d.Budget > 3000)).Take(2).Select(c => new {c.FirstName, c.LastName});
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData3" aria-labelledby="csharpSimpleOData3-tab">
+<div role="tabpanel" class="tab-pane " id="csharpSimpleOData3" aria-labelledby="csharpSimpleOData3-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -807,14 +789,8 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link" href="#http4" role="tab" aria-controls="http4"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle" href="#csharp4" role="tab" id="csharpDrop4" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop4-contents">C# &nbsp;<span
-            class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop4-contents">
-<li><a class="tab-link" href="#csharpCodeGen4" role="tab" id="csharpCodeGen4-tab" data-toggle="tab" aria-controls="csharpCodeGen4">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link" href="#csharpSimpleOData4" role="tab" id="csharpSimpleOData4-tab" data-toggle="tab" aria-controls="csharpSimpleOData4">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation"><a class="tab-link" href="#csharpCodeGen4" role="tab" id="csharpCodeGen4-tab" data-toggle="tab" aria-controls="csharpCodeGen4">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link" href="#csharpSimpleOData4" role="tab" id="csharpSimpleOData4-tab" data-toggle="tab" aria-controls="csharpSimpleOData4">C# Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link" href="#olingo-js-4" role="tab" aria-controls="olingo-js-4" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link" href="#odatacpp-4" role="tab" aria-controls="odatacpp-4" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link" href="#nodejs-4" role="tab" aria-controls="nodejs-4" data-toggle="tab">Node.js</a></li>
@@ -851,7 +827,7 @@ Region: 'ID'
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-post-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen4" aria-labelledby="csharpCodeGen4-tab">
+<div role="tabpanel" class="tab-pane " id="csharpCodeGen4" aria-labelledby="csharpCodeGen4-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var lewis = new Person()
@@ -877,7 +853,7 @@ context.SaveChanges();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData4" aria-labelledby="csharpSimpleOData4-tab">
+<div role="tabpanel" class="tab-pane " id="csharpSimpleOData4" aria-labelledby="csharpSimpleOData4-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -1071,14 +1047,8 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link" href="#http5" role="tab" aria-controls="http5"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle" href="#csharp5" role="tab" id="csharpDrop5" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop5-contents">C# &nbsp;<span
-            class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop5-contents">
-<li><a class="tab-link" href="#csharpCodeGen5" role="tab" id="csharpCodeGen5-tab" data-toggle="tab" aria-controls="csharpCodeGen5">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link" href="#csharpSimpleOData5" role="tab" id="csharpSimpleOData5-tab" data-toggle="tab" aria-controls="csharpSimpleOData5">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation"><a class="tab-link" href="#csharpCodeGen5" role="tab" id="csharpCodeGen5-tab" data-toggle="tab" aria-controls="csharpCodeGen5">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link" href="#csharpSimpleOData5" role="tab" id="csharpSimpleOData5-tab" data-toggle="tab" aria-controls="csharpSimpleOData5">C# Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link" href="#olingo-js-5" role="tab" aria-controls="olingo-js-5" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link" href="#odatacpp-5" role="tab" aria-controls="odatacpp-5" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link" href="#nodejs-5" role="tab" aria-controls="nodejs-5" data-toggle="tab">Node.js</a></li>
@@ -1098,7 +1068,7 @@ Content-Type: application/json
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-relationship-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen5" aria-labelledby="csharpCodeGen5-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen5">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var trip = context.People.ByKey(userName: "russellwhyte").Trips.ByKey(tripId: 0).GetValue();
@@ -1111,7 +1081,7 @@ dsc[0].Trips.Add(trip);</p>
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData5" aria-labelledby="csharpSimpleOData5-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData5">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -1240,14 +1210,8 @@ Download and install the Node.js platform from <a href="https://nodejs.org">node
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link" href="#http6" role="tab" aria-controls="http6"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation" class="dropdown">
-<a class="tab-link dropdown-toggle" href="#csharp6" role="tab" id="csharpDrop6" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-controls="csharpDrop1-contents">C# &nbsp;<span
-            class="caret"></span></a></p>
-<ul role="presentation" class="dropdown-menu tab-link" id="csharpDrop6-contents">
-<li><a class="tab-link" href="#csharpCodeGen6" role="tab" id="csharpCodeGen6-tab" data-toggle="tab" aria-controls="csharpCodeGen6">OData v4 Client Code Generator</a></li>
-<li><a class="tab-link" href="#csharpSimpleOData6" role="tab" id="csharpSimpleOData6-tab" data-toggle="tab" aria-controls="csharpSimpleOData6">Simple.OData.Client</a></li>
-</ul>
-</li>
+<li role="presentation"><a class="tab-link" href="#csharpCodeGen6" role="tab" id="csharpCodeGen6-tab" data-toggle="tab" aria-controls="csharpCodeGen6">OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link" href="#csharpSimpleOData6" role="tab" id="csharpSimpleOData6-tab" data-toggle="tab" aria-controls="csharpSimpleOData6">Simple.OData.Client</a></li>
 <li role="presentation"><a class="tab-link" href="#olingo-js-6" role="tab" aria-controls="olingo-js-6" data-toggle="tab">Olingo JavaScript client</a></li>
 <li role="presentation"><a class="tab-link" href="#odatacpp-6" role="tab" aria-controls="odatacpp-6" data-toggle="tab">C++</a></li>
 <li role="presentation"><a class="tab-link" href="#nodejs-6" role="tab" aria-controls="nodejs-6" data-toggle="tab">Node.js</a></li>
@@ -1263,7 +1227,7 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-function-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpCodeGen6" aria-labelledby="csharpCodeGen6-tab">
+<div role="tabpanel" class="tab-pane " id="csharpCodeGen6" aria-labelledby="csharpCodeGen6-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new
 Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
@@ -1272,7 +1236,7 @@ var people = trip.GetInvolvedPeople().Execute();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane fade" id="csharpSimpleOData6" aria-labelledby="csharpSimpleOData6-tab">
+<div role="tabpanel" class="tab-pane " id="csharpSimpleOData6" aria-labelledby="csharpSimpleOData6-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -693,14 +693,14 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-query-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpCodeGen3" aria-labelledby="csharpCodeGen3-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen3" aria-labelledby="csharpCodeGen3-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var people = context.People.Where(c => c.Trips.Any(d => d.Budget > 3000)).Take(2).Select(c => new {c.FirstName, c.LastName});
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpSimpleOData3" aria-labelledby="csharpSimpleOData3-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData3" aria-labelledby="csharpSimpleOData3-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -827,7 +827,7 @@ Region: 'ID'
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-post-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpCodeGen4" aria-labelledby="csharpCodeGen4-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen4" aria-labelledby="csharpCodeGen4-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
 var lewis = new Person()
@@ -853,7 +853,7 @@ context.SaveChanges();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpSimpleOData4" aria-labelledby="csharpSimpleOData4-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData4" aria-labelledby="csharpSimpleOData4-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");
@@ -1227,7 +1227,7 @@ OData-MaxVersion: 4.0
 {% endhighlight %}
 <button class="btn btn-primary step-buttons" data-toggle="modal" data-target="#step-function-modal">View the response</button>
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpCodeGen6" aria-labelledby="csharpCodeGen6-tab">
+<div role="tabpanel" class="tab-pane" id="csharpCodeGen6" aria-labelledby="csharpCodeGen6-tab">
 {% highlight csharp %}
 var context = new DefaultContainer(new
 Uri("https://services.odata.org/v4/(S(34wtn2c0hkuk5ekg0pjr513b))/TripPinServiceRW/"));
@@ -1236,7 +1236,7 @@ var people = trip.GetInvolvedPeople().Execute();
 {% endhighlight %}
 The client library used is the <a href="https://visualstudiogallery.msdn.microsoft.com/9b786c0e-79d1-4a50-89a5-125e57475937">OData v4 Client Code Generator</a>.
 </div>
-<div role="tabpanel" class="tab-pane " id="csharpSimpleOData6" aria-labelledby="csharpSimpleOData6-tab">
+<div role="tabpanel" class="tab-pane" id="csharpSimpleOData6" aria-labelledby="csharpSimpleOData6-tab">
 <b>Typed syntax</b>
 {% highlight csharp %}
 var client = new ODataClient("https://services.odata.org/v4/TripPinServiceRW/");

--- a/pages/getting-started/understand-odata-in-6-steps.html
+++ b/pages/getting-started/understand-odata-in-6-steps.html
@@ -472,12 +472,12 @@ OData-Version: 4.0
 <div class="code-row bottom-margin">
 <ul class="nav nav-tabs" role="tablist">
 <li role="presentation" class="active"><a class="tab-link"  href="#http1" role="tab" aria-controls="http1"  data-toggle="tab">HTTP request</a></li>
-<li role="presentation"><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1" aria-label="C sharp OData v4 Client Code Generator">C# OData v4 Client Code Generator</a></li>
-<li role="presentation"><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1" aria-label="C sharp Simple.OData.Client">C# Simple.OData.Client</a></li>
-<li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab" aria-label="Olingo JavaScript client">Olingo JavaScript client</a></li>
-<li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab" aria-label="C++">C++</a></li>
-<li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab" aria-label="Node.js">Node.js</a></li>
-<li role="presentation"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab" aria-label="Contribute">Contribute</a></li>
+<li role="presentation"><a class="tab-link"  href="#csharpCodeGen1" role="tab" id="csharpCodeGen1-tab" data-toggle="tab" aria-controls="csharpCodeGen1">C# OData v4 Client Code Generator</a></li>
+<li role="presentation"><a class="tab-link"  href="#csharpSimpleOData1" role="tab" id="csharpSimpleOData1-tab" data-toggle="tab" aria-controls="csharpSimpleOData1">C# Simple.OData.Client</a></li>
+<li role="presentation"><a class="tab-link"  href="#olingo-js-1" role="tab" aria-controls="olingo-js-1" data-toggle="tab">Olingo JavaScript client</a></li>
+<li role="presentation"><a class="tab-link"  href="#odatacpp-1" role="tab" aria-controls="odatacpp-1" data-toggle="tab">C++</a></li>
+<li role="presentation"><a class="tab-link"  href="#nodejs-1" role="tab" aria-controls="nodejs-1" data-toggle="tab" >Node.js</a></li>
+<li role="presentation"><a class="tab-link" href="#contribute-1" role="tab" aria-controls="contribute-1" data-toggle="tab">Contribute</a></li>
 </ul>
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="http1">

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -25,6 +25,7 @@
     40: 1,
   };
 
+  var firstTab = null;
   tablists.forEach(tablist => {
       let tabs = [];
       let panels = [];
@@ -42,14 +43,13 @@
         addListeners(i);
       };
 
-      deactivateTabs();
-      activateTab(tabs[0]);
-
       function addListeners (index) {
         tabs[index].addEventListener('keydown', keydownEventListener);
 
         tabs[index].addEventListener('keyup', keyupEventListener);
         tabs[index].addEventListener('click', clickEventListener);
+        tabs[index].addEventListener('focus', focusEventHandler);
+
         tabs[index].index = index;
       };
 
@@ -268,14 +268,12 @@
       //
       function focusEventHandler (event) {
         var target = event.target;
-
         setTimeout(checkTabFocus, delay, target);
       };
 
       // Only activate tab on focus if it still has focus after the delay
       function checkTabFocus (target) {
         focused = document.activeElement;
-
         if (target === focused) {
           activateTab(target, false);
         };

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -17,7 +17,7 @@
     delete: 46,
   };
 
-  // Add or substract depending on key pressed
+  // Add or substract depending on key pressed -1 is left or bottom to up while 1 is top to bottom and right
   var direction = {
     37: -1,
     38: -1,
@@ -49,11 +49,7 @@
         tabs[index].addEventListener('keydown', keydownEventListener);
 
         tabs[index].addEventListener('keyup', keyupEventListener);
-        tabs[index].addEventListener('click', function(e) {
-            clickEventListener(e);
-        });
-
-        // Build an array with all tabs (<button>s) in it
+        tabs[index].addEventListener('click', clickEventListener);
         tabs[index].index = index;
       };
 
@@ -135,7 +131,7 @@
       };
 
       // Either focus the next, previous, first, or last tab
-      // depening on key pressed
+      // depending on key pressed
       function switchTabOnArrowPress (event) {
         var pressed = event.keyCode;
 
@@ -179,10 +175,6 @@
 
         // Remove hidden attribute from tab panel to make it visible
         var tabContent = document.getElementById(controls);
-        if(tabContent === undefined || tabContent === null)
-        {
-          debugger;
-        }
 
         tabContent.removeAttribute('hidden');
         tabContent.setAttribute('tabindex', '0');
@@ -213,12 +205,12 @@
         }
       };
 
-      // Make a guess
+      // Focus the first child
       function focusFirstTab () {
         tabs[0].focus();
       };
 
-      // Make a guess
+      // Focus the last child
       function focusLastTab () {
         tabs[tabs.length - 1].focus();
       };

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -4,7 +4,7 @@
 */
 (function () {
   // need to group them into smaller tab list items
-  
+
   var tablists = document.querySelectorAll('[role="tablist"]');
   // For easy reference
   var keys = {
@@ -14,7 +14,7 @@
     up: 38,
     right: 39,
     down: 40,
-    delete: 46
+    delete: 46,
   };
 
   // Add or substract depending on key pressed
@@ -22,7 +22,7 @@
     37: -1,
     38: -1,
     39: 1,
-    40: 1
+    40: 1,
   };
 
   tablists.forEach(tablist => {
@@ -42,9 +42,16 @@
         addListeners(i);
       };
 
+      deactivateTabs();
+      activateTab(tabs[0]);
+
       function addListeners (index) {
         tabs[index].addEventListener('keydown', keydownEventListener);
+
         tabs[index].addEventListener('keyup', keyupEventListener);
+        tabs[index].addEventListener('click', function(e) {
+            clickEventListener(e);
+        });
 
         // Build an array with all tabs (<button>s) in it
         tabs[index].index = index;
@@ -53,7 +60,7 @@
       // When a tab is clicked, activateTab is fired to activate it
       function clickEventListener (event) {
         var tab = event.target;
-        activateTab(tab, false);
+        activateTab(tab, true);
       };
 
       // Handle keydown on tabs
@@ -84,6 +91,12 @@
       // Handle keyup on tabs
       function keyupEventListener (event) {
         var key = event.keyCode;
+
+        if (key == " " || event.code == "Space" || key == 32  || event.code == "Enter" || key == 13	) {
+          event.preventDefault();
+          clickEventListener(event);
+          return;
+        }
 
         switch (key) {
           case keys.left:
@@ -148,6 +161,7 @@
 
       // Activates any given tab panel
       function activateTab (tab, setFocus) {
+
         setFocus = setFocus || true;
         // Deactivate all other tabs
         deactivateTabs();
@@ -165,6 +179,11 @@
 
         // Remove hidden attribute from tab panel to make it visible
         var tabContent = document.getElementById(controls);
+        if(tabContent === undefined || tabContent === null)
+        {
+          debugger;
+        }
+
         tabContent.removeAttribute('hidden');
         tabContent.setAttribute('tabindex', '0');
         tabContent.setAttribute('aria-hidden', 'false');

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -25,7 +25,6 @@
     40: 1,
   };
 
-  var firstTab = null;
   tablists.forEach(tablist => {
       let tabs = [];
       let panels = [];

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -3,18 +3,9 @@
 *   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
 */
 (function () {
-  var tablist = document.querySelectorAll('[role="tablist"]')[0];
-  var tabs;
-  var panels;
-  var delay = determineDelay();
-
-  generateArrays();
-
-  function generateArrays () {
-    tabs = document.querySelectorAll('[role="tab"]');
-    panels = document.querySelectorAll('[role="tabpanel"]');
-  };
-
+  // need to group them into smaller tab list items
+  
+  var tablists = document.querySelectorAll('[role="tablist"]');
   // For easy reference
   var keys = {
     end: 35,
@@ -34,236 +25,250 @@
     40: 1
   };
 
-  // Bind listeners
-  for (i = 0; i < tabs.length; ++i) {
-    addListeners(i);
-  };
+  tablists.forEach(tablist => {
+      let tabs = [];
+      let panels = [];
+      let delay = determineDelay();
 
-  function addListeners (index) {
-    tabs[index].addEventListener('keydown', keydownEventListener);
-    tabs[index].addEventListener('keyup', keyupEventListener);
-
-    // Build an array with all tabs (<button>s) in it
-    tabs[index].index = index;
-  };
-
-  // When a tab is clicked, activateTab is fired to activate it
-  function clickEventListener (event) {
-    var tab = event.target;
-    activateTab(tab, false);
-  };
-
-  // Handle keydown on tabs
-  function keydownEventListener (event) {
-    var key = event.keyCode;
-
-    switch (key) {
-      case keys.end:
-        event.preventDefault();
-        // Activate last tab
-        activateTab(tabs[tabs.length - 1]);
-        break;
-      case keys.home:
-        event.preventDefault();
-        // Activate first tab
-        activateTab(tabs[0]);
-        break;
-
-      // Up and down are in keydown
-      // because we need to prevent page scroll >:)
-      case keys.up:
-      case keys.down:
-        determineOrientation(event);
-        break;
-    };
-  };
-
-  // Handle keyup on tabs
-  function keyupEventListener (event) {
-    var key = event.keyCode;
-
-    switch (key) {
-      case keys.left:
-      case keys.right:
-        determineOrientation(event);
-        break;
-      case keys.delete:
-        determineDeletable(event);
-        break;
-    };
-  };
-
-  // When a tablist's aria-orientation is set to vertical,
-  // only up and down arrow should function.
-  // In all other cases only left and right arrow function.
-  function determineOrientation (event) {
-    var key = event.keyCode;
-    var vertical = tablist.getAttribute('aria-orientation') == 'vertical';
-    var proceed = false;
-
-    if (vertical) {
-      if (key === keys.up || key === keys.down) {
-        event.preventDefault();
-        proceed = true;
-      };
-    }
-    else {
-      if (key === keys.left || key === keys.right) {
-        proceed = true;
-      };
-    };
-
-    if (proceed) {
-      switchTabOnArrowPress(event);
-    };
-  };
-
-  // Either focus the next, previous, first, or last tab
-  // depening on key pressed
-  function switchTabOnArrowPress (event) {
-    var pressed = event.keyCode;
-
-    for (x = 0; x < tabs.length; x++) {
-      tabs[x].addEventListener('focus', focusEventHandler);
-    };
-
-    if (direction[pressed]) {
-      var target = event.target;
-      if (target.index !== undefined) {
-        if (tabs[target.index + direction[pressed]]) {
-          tabs[target.index + direction[pressed]].focus();
-        }
-        else if (pressed === keys.left || pressed === keys.up) {
-          focusLastTab();
-        }
-        else if (pressed === keys.right || pressed == keys.down) {
-          focusFirstTab();
-        };
-      };
-    };
-  };
-
-  // Activates any given tab panel
-  function activateTab (tab, setFocus) {
-    setFocus = setFocus || true;
-    // Deactivate all other tabs
-    deactivateTabs();
-
-    // Remove tabindex attribute
-    tab.setAttribute('tabindex', '0');
-
-    // Set the tab as selected
-    tab.classList.add('active');
-    tab.parentElement.classList.add('active');
-    tab.setAttribute('aria-selected', 'true');
-
-    // Get the value of aria-controls (which is an ID)
-    var controls = tab.getAttribute('aria-controls');
-
-    // Remove hidden attribute from tab panel to make it visible
-    var tabContent = document.getElementById(controls);
-    tabContent.removeAttribute('hidden');
-    tabContent.setAttribute('tabindex', '0');
-    tabContent.setAttribute('aria-hidden', 'false');
-    tabContent.classList.add('active');
-
-    // Set focus when required
-    if (setFocus) {
-      tab.focus();
-    };
-  };
-
-  // Deactivate all tabs and tab panels
-  function deactivateTabs () {
-    for (t = 0; t < tabs.length; t++) {
-      tabs[t].setAttribute('tabindex', '-1');
-      tabs[t].setAttribute('aria-selected', 'false');
-      tabs[t].classList.remove('active');
-      tabs[t].parentElement.classList.remove('active');
-      tabs[t].removeEventListener('focus', focusEventHandler);
-    };
-
-    for (p = 0; p < panels.length; p++) {
-      panels[p].setAttribute('hidden', 'hidden');
-      panels[p].setAttribute('tabindex', '-1');
-      panels[p].setAttribute('aria-hidden', 'true');
-      panels[p].classList.remove('active');
-    };
-  };
-
-  // Make a guess
-  function focusFirstTab () {
-    tabs[0].focus();
-  };
-
-  // Make a guess
-  function focusLastTab () {
-    tabs[tabs.length - 1].focus();
-  };
-
-  // Detect if a tab is deletable
-  function determineDeletable (event) {
-    target = event.target;
-
-    if (target.getAttribute('data-deletable') !== null) {
-      // Delete target tab
-      deleteTab(event, target);
-
-      // Update arrays related to tabs widget
       generateArrays();
 
-      // Activate the closest tab to the one that was just deleted
-      if (target.index - 1 < 0) {
-        activateTab(tabs[0]);
-      }
-      else {
-        activateTab(tabs[target.index - 1]);
+      function generateArrays () {
+        tabs.push.apply(tabs, tablist.querySelectorAll('[role="tab"]'));
+        panels.push.apply(panels, tablist.parentElement.querySelectorAll('[role="tabpanel"]'));
       };
-    };
-  };
 
-  // Deletes a tab and its panel
-  function deleteTab (event) {
-    var target = event.target;
-    var panel = document.getElementById(target.getAttribute('aria-controls'));
-
-    target.parentElement.removeChild(target);
-    panel.parentElement.removeChild(panel);
-  };
-
-  // Determine whether there should be a delay
-  // when user navigates with the arrow keys
-  function determineDelay () {
-    var hasDelay = tablist.hasAttribute('data-delay');
-    var delay = 0;
-
-    if (hasDelay) {
-      var delayValue = tablist.getAttribute('data-delay');
-      if (delayValue) {
-        delay = delayValue;
-      }
-      else {
-        // If no value is specified, default to 300ms
-        delay = 300;
+      // Bind listeners
+      for (i = 0; i < tabs.length; ++i) {
+        addListeners(i);
       };
-    };
 
-    return delay;
-  };
+      function addListeners (index) {
+        tabs[index].addEventListener('keydown', keydownEventListener);
+        tabs[index].addEventListener('keyup', keyupEventListener);
 
-  //
-  function focusEventHandler (event) {
-    var target = event.target;
+        // Build an array with all tabs (<button>s) in it
+        tabs[index].index = index;
+      };
 
-    setTimeout(checkTabFocus, delay, target);
-  };
+      // When a tab is clicked, activateTab is fired to activate it
+      function clickEventListener (event) {
+        var tab = event.target;
+        activateTab(tab, false);
+      };
 
-  // Only activate tab on focus if it still has focus after the delay
-  function checkTabFocus (target) {
-    focused = document.activeElement;
+      // Handle keydown on tabs
+      function keydownEventListener (event) {
+        var key = event.keyCode;
 
-    if (target === focused) {
-      activateTab(target, false);
-    };
-  };
+        switch (key) {
+          case keys.end:
+            event.preventDefault();
+            // Activate last tab
+            activateTab(tabs[tabs.length - 1]);
+            break;
+          case keys.home:
+            event.preventDefault();
+            // Activate first tab
+            activateTab(tabs[0]);
+            break;
+
+          // Up and down are in keydown
+          // because we need to prevent page scroll >:)
+          case keys.up:
+          case keys.down:
+            determineOrientation(event);
+            break;
+        };
+      };
+
+      // Handle keyup on tabs
+      function keyupEventListener (event) {
+        var key = event.keyCode;
+
+        switch (key) {
+          case keys.left:
+          case keys.right:
+            determineOrientation(event);
+            break;
+          case keys.delete:
+            determineDeletable(event);
+            break;
+        };
+      };
+
+      // When a tablist's aria-orientation is set to vertical,
+      // only up and down arrow should function.
+      // In all other cases only left and right arrow function.
+      function determineOrientation (event) {
+        var key = event.keyCode;
+        var vertical = tablist.getAttribute('aria-orientation') == 'vertical';
+        var proceed = false;
+
+        if (vertical) {
+          if (key === keys.up || key === keys.down) {
+            event.preventDefault();
+            proceed = true;
+          };
+        }
+        else {
+          if (key === keys.left || key === keys.right) {
+            proceed = true;
+          };
+        };
+
+        if (proceed) {
+          switchTabOnArrowPress(event);
+        };
+      };
+
+      // Either focus the next, previous, first, or last tab
+      // depening on key pressed
+      function switchTabOnArrowPress (event) {
+        var pressed = event.keyCode;
+
+        for (x = 0; x < tabs.length; x++) {
+          tabs[x].addEventListener('focus', focusEventHandler);
+        };
+
+        if (direction[pressed]) {
+          var target = event.target;
+          if (target.index !== undefined) {
+            if (tabs[target.index + direction[pressed]]) {
+              tabs[target.index + direction[pressed]].focus();
+            }
+            else if (pressed === keys.left || pressed === keys.up) {
+              focusLastTab();
+            }
+            else if (pressed === keys.right || pressed == keys.down) {
+              focusFirstTab();
+            };
+          };
+        };
+      };
+
+      // Activates any given tab panel
+      function activateTab (tab, setFocus) {
+        setFocus = setFocus || true;
+        // Deactivate all other tabs
+        deactivateTabs();
+
+        // Remove tabindex attribute
+        tab.setAttribute('tabindex', '0');
+
+        // Set the tab as selected
+        tab.classList.add('active');
+        tab.parentElement.classList.add('active');
+        tab.setAttribute('aria-selected', 'true');
+
+        // Get the value of aria-controls (which is an ID)
+        var controls = tab.getAttribute('aria-controls');
+
+        // Remove hidden attribute from tab panel to make it visible
+        var tabContent = document.getElementById(controls);
+        tabContent.removeAttribute('hidden');
+        tabContent.setAttribute('tabindex', '0');
+        tabContent.setAttribute('aria-hidden', 'false');
+        tabContent.classList.add('active');
+
+        // Set focus when required
+        if (setFocus) {
+          tab.focus();
+        };
+      };
+
+      // Deactivate all tabs and tab panels
+      function deactivateTabs () {
+        for (let t = 0; t < tabs.length; t++) {
+          tabs[t].setAttribute('tabindex', '-1');
+          tabs[t].setAttribute('aria-selected', 'false');
+          tabs[t].classList.remove('active');
+          tabs[t].parentElement.classList.remove('active');
+          tabs[t].removeEventListener('focus', focusEventHandler);
+        }
+
+        for (let p = 0; p < panels.length; p++) {
+          panels[p].setAttribute('hidden', 'hidden');
+          panels[p].setAttribute('tabindex', '-1');
+          panels[p].setAttribute('aria-hidden', 'true');
+          panels[p].classList.remove('active');
+        }
+      };
+
+      // Make a guess
+      function focusFirstTab () {
+        tabs[0].focus();
+      };
+
+      // Make a guess
+      function focusLastTab () {
+        tabs[tabs.length - 1].focus();
+      };
+
+      // Detect if a tab is deletable
+      function determineDeletable (event) {
+        target = event.target;
+
+        if (target.getAttribute('data-deletable') !== null) {
+          // Delete target tab
+          deleteTab(event, target);
+
+          // Update arrays related to tabs widget
+          generateArrays();
+
+          // Activate the closest tab to the one that was just deleted
+          if (target.index - 1 < 0) {
+            activateTab(tabs[0]);
+          }
+          else {
+            activateTab(tabs[target.index - 1]);
+          };
+        };
+      };
+
+      // Deletes a tab and its panel
+      function deleteTab (event) {
+        var target = event.target;
+        var panel = document.getElementById(target.getAttribute('aria-controls'));
+
+        target.parentElement.removeChild(target);
+        panel.parentElement.removeChild(panel);
+      };
+
+      // Determine whether there should be a delay
+      // when user navigates with the arrow keys
+      function determineDelay () {
+        var hasDelay = tablist.hasAttribute('data-delay');
+        var delay = 0;
+
+        if (hasDelay) {
+          var delayValue = tablist.getAttribute('data-delay');
+          if (delayValue) {
+            delay = delayValue;
+          }
+          else {
+            // If no value is specified, default to 300ms
+            delay = 300;
+          };
+        };
+
+        return delay;
+      };
+
+      //
+      function focusEventHandler (event) {
+        var target = event.target;
+
+        setTimeout(checkTabFocus, delay, target);
+      };
+
+      // Only activate tab on focus if it still has focus after the delay
+      function checkTabFocus (target) {
+        focused = document.activeElement;
+
+        if (target === focused) {
+          activateTab(target, false);
+        };
+      };
+  });
+  
 }());

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -100,7 +100,7 @@
             determineOrientation(event);
             break;
           case keys.delete:
-            determineDeletable(event);
+            deleteTabIfDeletable(event);
             break;
         };
       };
@@ -216,7 +216,7 @@
       };
 
       // Detect if a tab is deletable
-      function determineDeletable (event) {
+      function deleteTabIfDeletable (event) {
         target = event.target;
 
         if (target.getAttribute('data-deletable') !== null) {


### PR DESCRIPTION
Fixes a bug which causes narrator to announce all the focused tabs as selected when navigating.
The bug was due to the JavaScript code causing activations when scanning through the elements but these did not reflect on the tab elements due to how narrator modifies navigation.

The click event listener had also not been bound causing tab activation to fail.
## Original behavior:

https://github.com/user-attachments/assets/878a8650-b27c-44de-baca-24b6149d3e77

## Fixed



https://github.com/user-attachments/assets/b75e9836-73bf-475b-8da2-f05c7fd19078




