### PR TITLE
Update information for unmaintained libraries Apache Olingo and odata4j

### DIFF
--- a/_libraries/Apache-Olingo.md
+++ b/_libraries/Apache-Olingo.md
@@ -1,6 +1,6 @@
 ---
 category: java
-name: Apache Olingo <span class="label label-success">featured</span>
+name: Apache Olingo <span class="label label-success">Archived on Dec 2025</span>
 rownumber: 13
 version: V2 and V4
 object: Both

--- a/_libraries/ODataJS.md
+++ b/_libraries/ODataJS.md
@@ -1,6 +1,6 @@
 ---
 category: javascript
-name: ODataJS <span class="label label-success">featured</span> 
+name: ODataJS <span class="label label-success">Archived on Dec 2025</span> 
 rownumber: 25
 version: V4
 object: Client

--- a/_libraries/odata4j.md
+++ b/_libraries/odata4j.md
@@ -1,6 +1,6 @@
 ---
 category: java
-name: odata4j
+name: odata4j <span class="label label-success">Unmaintained</span>
 rownumber: 7
 version: V1-V3
 object: Both


### PR DESCRIPTION
Apache Olingo project going to Apache Attic (which means it is archived and won't be maintained anymore): https://attic.apache.org/projects/olingo.html https://issues.apache.org/jira/browse/ATTIC-251

Odata4j is archived https://code.google.com/archive/p/odata4j/ the links to download latest stable version are no more working, they are pointing to bintray