### PR TITLE
Add jamolingo java library

### DIFF
--- a/_libraries/Jamolingo.md
+++ b/_libraries/Jamolingo.md
@@ -1,0 +1,12 @@
+---
+category: java
+name: Jamolingo
+link: https://github.com/starnowski/jamolingo
+version: V4
+object: Server
+downloads:
+    - source: GitHub
+      link: https://github.com/starnowski/jamolingo/releases
+---
+Jamolingo is a Java library designed to translate OData queries and concepts into MongoDB aggregation pipelines, leveraging Apache Olingo
+5.0. It serves as a server-side (producer) building block for mapping OData Entity Data Models (EDM) to MongoDB document structures.     

--- a/_libraries/Jamolingo.md
+++ b/_libraries/Jamolingo.md
@@ -8,5 +8,5 @@ downloads:
     - source: GitHub
       link: https://github.com/starnowski/jamolingo/releases
 ---
-Jamolingo is a Java library designed to translate OData queries and concepts into MongoDB aggregation pipelines, leveraging Apache Olingo
-5.0. It serves as a server-side (producer) building block for mapping OData Entity Data Models (EDM) to MongoDB document structures.     
+Jamolingo is a Java library designed to translate OData queries and concepts into MongoDB aggregation pipelines, leveraging Apache Olingo 5.0.
+It serves as a server-side (producer) building block for mapping OData Entity Data Models (EDM) to MongoDB document structures.


### PR DESCRIPTION
https://github.com/OData/odataorg.github.io/issues/390

The OData ecosystem has recently gained a new library: [Jamolingo](https://github.com/starnowski/jamolingo)
.

This library enables translation of OData query syntax into MongoDB queries and aggregation pipelines within the Java ecosystem. It may be a valuable addition to the list of OData-related libraries and tools showcased on the site.

Why this matters

Expands OData support for MongoDB inJAVA
Provides a Java-based solution for OData query parsing and execution against NoSQL databases