### PR TITLE
fix(a11y): add persistent label to search input field

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -88,9 +88,9 @@
 
                 <form class="navbar-form navbar-left" role="search">
                     <div class="form-group combobox combobox-list">
+                        <label for="main-search-input" class="visually-hidden">Search the OData website</label>
                         <input id="main-search-input"
                                type="text"
-                               aria-label="Search"
                                class="form-control st-default-search-input"
                                placeholder="Search"
                                role="combobox"


### PR DESCRIPTION
Fix missing persistent label on the search suggestion input:

- [OData - Home]: Search suggestion input field lacked persistent label/instructions — only had a placeholder that disappears on input

Changes:
- Add visually-hidden <label> element associated with the search input via for/id relationship
- Label text 'Search the OData website' provides clear instructions
- Remove redundant aria-label since <label> now provides the accessible name (preferred per WCAG best practices)
- Uses existing .visually-hidden CSS class for visual hiding while remaining accessible to screen readers

Meets WCAG 2.1 AA criteria 1.3.1 (Info and Relationships) and 3.3.2 (Labels or Instructions).