### PR TITLE
fix(a11y): improve content reflow and visibility at 400% zoom

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -308,6 +308,36 @@ table.reflows.cell-label {
   table.reflows tr:nth-child(odd) {
         background-color: #F9F9F9;
   }
+
+  /* WCAG 2.1 AA — Reflow at 400% zoom (1.4.10) */
+
+  /* Issue 1: Carousel caption truncation */
+  .carousel-caption {
+    position: relative;
+    margin: 10px 0;
+    max-height: none;
+  }
+  .carousel img {
+    min-height: 0;
+  }
+
+  /* Issue 2: Pre/code blocks overflow */
+  pre {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+
+  /* Issue 3: Two-column layout doesn't stack */
+  .col-2-3, .col-1-3 {
+    width: 100%;
+    float: none;
+  }
+  /* Issue 4: Long URLs and inline code overflow containers */
+  a, code, td {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+  }
 }
 
 body {


### PR DESCRIPTION
Fix zoom and responsive layout issues for WCAG 2.1 AA compliance (1.4.10 Reflow):

- [OData - Home]: Carousel caption ('Recent Posts') no longer truncated at 400% zoom — switches to relative positioning and removes height constraints at narrow viewports
- [OData - Developers - OData Version 3.0 Core Protocol]: Table content under 'Logical Operators' now wraps with pre-wrap at high zoom instead of overflowing
- [OData - Developers - Advanced Tutorial]: Two-column layout (.col-2-3, .col-1-3) stacks to full width at 400% zoom, making 'Singleton' links visible
- [OData - Developers - OData Version 3.0 Atom Format]: Long URLs under 'OData Data Namespace' now break correctly using overflow-wrap: break-word

All responsive fixes consolidated in a single @media block (max-width: 640px) for maintainability.