### PR TITLE
fix(a11y): ensure focus is visible inside search typeahead suggestions

### DIFF
--- a/public/css/autocomplete.css
+++ b/public/css/autocomplete.css
@@ -49,6 +49,15 @@ form input.st-search-input {
     text-align: left;
 }
 
+.swiftype-widget .autocomplete ul[role="listbox"] {
+    max-height: 300px;
+    overflow-y: auto;
+}
+
+.swiftype-widget .autocomplete ul.focus {
+    outline: 2px solid #955000;
+}
+
 .swiftype-widget .autocomplete li > a:hover {
     text-decoration: none;
 }
@@ -81,27 +90,32 @@ form input.st-search-input {
 }
 
 .swiftype-widget .autocomplete li.active,
-.swiftype-widget .autocomplete li:hover:focus {
-    border: 2px solid #c34113;
+.swiftype-widget .autocomplete li:hover:focus,
+.swiftype-widget .autocomplete li[aria-selected="true"] {
+    border: 2px solid #955000;
     background-color: transparent;
     background: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, #fff), color-stop(100%, #f9f2f4));
     background: -webkit-linear-gradient(#fff, #f9f2f4);
     background: -moz-linear-gradient(#fff, #f9f2f4);
     background: -o-linear-gradient(#fff, #f9f2f4);
     background: linear-gradient(#fff, #f9f2f4);
+    outline: 2px solid #955000;
+    outline-offset: -2px;
     -webkit-box-shadow: 0 1px 0 #f9f2f4 inset;
     -moz-box-shadow: 0 1px 0 #f9f2f4 inset;
     box-shadow: 0 1px 0 #f9f2f4 inset;
 }
 
 .swiftype-widget .autocomplete li.active .autocomplete-result__title,
-.swiftype-widget .autocomplete li:hover:focus .autocomplete-result__title {
+.swiftype-widget .autocomplete li:hover:focus .autocomplete-result__title,
+.swiftype-widget .autocomplete li[aria-selected="true"] .autocomplete-result__title {
     font-weight: bold;
     text-decoration: underline;
 }
 
 .swiftype-widget .autocomplete li.active .autocomplete-result__description,
-.swiftype-widget .autocomplete li:hover:focus .autocomplete-result__description {
+.swiftype-widget .autocomplete li:hover:focus .autocomplete-result__description,
+.swiftype-widget .autocomplete li[aria-selected="true"] .autocomplete-result__description {
     font-weight: bold;
     text-decoration: underline;
 }


### PR DESCRIPTION
Fix focus visibility in the search autocomplete dropdown so keyboard users can see which suggestion is currently focused:

- [OData - Home]: Focus was obscured inside search typeahead suggestions — keyboard navigation through results had no visible focus indicator

Changes:
- Add max-height and overflow-y to listbox container so the scroll-into-view logic in combobox-autocomplete.js works properly
- Add aria-selected='true' as a CSS selector alongside .active and :hover:focus for consistent focus styling via keyboard
- Add visible outline to listbox container when it has visual focus
- Use #955000 (6.13:1 contrast) for all focus indicators

Meets WCAG 2.1 AA criteria 2.4.7 (Focus Visible) and 2.4.11 (Focus Not Obscured).