### PR TITLE
fix(a11y): improve screen reader support and ARIA semantics

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -25,7 +25,7 @@
             <div class="collapse navbar-collapse" id="odata-navbar-collapse" role="navigation">
                 <ul class="nav navbar-nav" role="menubar">
                     <li role="none">
-                        <a role="menuitem" href="/blog">Blog</a>
+                        <a role="menuitem" href="/blog" {% if page.url == '/blog/' or page.url contains '/blog' %}aria-current="page"{% endif %}>Blog</a>
                     </li>
                     <li class="dropdown" role="none">
                         <a role="menuitem"
@@ -34,24 +34,25 @@
                            class="dropdown-toggle"
                            data-toggle="dropdown"
                            data-target="#"
-                           href="#">
+                           href="#"
+                           {% if page.url contains '/getting-started' or page.url contains '/documentation' or page.url contains '/libraries' or page.url contains '/odata-services' or page.url contains '/odata-icon-usage-guidelines' %}aria-current="true"{% endif %}>
                             Developers <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" role="menu" aria-label="Developers dropdown.">
+                        <ul class="dropdown-menu" role="menu">
                             <li role="none">
-                                <a role="menuitem" href="/getting-started">Getting Started</a>
+                                <a role="menuitem" href="/getting-started" {% if page.url == '/getting-started/' or page.url contains '/getting-started' %}aria-current="page"{% endif %}>Getting Started</a>
                             </li>
                             <li role="none">
-                                <a role="menuitem" href="/documentation">Documentation</a>
+                                <a role="menuitem" href="/documentation" {% if page.url == '/documentation/' or page.url contains '/documentation' %}aria-current="page"{% endif %}>Documentation</a>
                             </li>
                             <li role="none">
-                                <a role="menuitem" href="/libraries">Libraries</a>
+                                <a role="menuitem" href="/libraries" {% if page.url == '/libraries/' or page.url contains '/libraries' %}aria-current="page"{% endif %}>Libraries</a>
                             </li>
                             <li role="none">
-                                <a role="menuitem" href="/odata-services">Reference Services</a>
+                                <a role="menuitem" href="/odata-services" {% if page.url == '/odata-services/' or page.url contains '/odata-services' %}aria-current="page"{% endif %}>Reference Services</a>
                             </li>
                             <li role="none">
-                                <a role="menuitem" href="/odata-icon-usage-guidelines/">Icon Usage</a>
+                                <a role="menuitem" href="/odata-icon-usage-guidelines/" {% if page.url contains '/odata-icon-usage-guidelines' %}aria-current="page"{% endif %}>Icon Usage</a>
                             </li>
                         </ul>
                     </li>
@@ -65,7 +66,7 @@
                            href="#">
                             Tools <b class="caret"></b>
                         </a>
-                        <ul class="dropdown-menu" role="menu" aria-label="Tools dropdown.">
+                        <ul class="dropdown-menu" role="menu">
                             <li role="none">
                                 <a role="menuitem"
                                    href="https://marketplace.visualstudio.com/items?itemName=stansw.vscode-odata"
@@ -79,10 +80,10 @@
                         </ul>
                     </li>
                     <li role="none">
-                        <a role="menuitem"  href="/ecosystem">Ecosystem</a>
+                        <a role="menuitem"  href="/ecosystem" {% if page.url == '/ecosystem/' or page.url contains '/ecosystem' %}aria-current="page"{% endif %}>Ecosystem</a>
                     </li>
                     <li role="none">
-                        <a role="menuitem" href="/contribution">Getting Involved</a>
+                        <a role="menuitem" href="/contribution" {% if page.url == '/contribution/' or page.url contains '/contribution' %}aria-current="page"{% endif %}>Getting Involved</a>
                     </li>
                 </ul>
 

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -67,10 +67,14 @@
                     section = result.sections[1] || '';
                 }
 
+                // Ensure title is never undefined and strip HTML tags for aria-label
+                title = title || 'Search result';
+                var ariaTitle = String(title).replace(/<[^>]*>/g, '');
+
                 return $(
-                    '<li role="option" id="' + result['id'] + '" class="autocomplete-result"  aria-label="' + title + '"><a href="' + url + '">' +
+                    '<li role="option" id="' + result['id'] + '" class="autocomplete-result"  aria-label="' + ariaTitle + '"><a href="' + url + '">' +
                     '<span\n        class="autocomplete-result__title">' + section + '</span> <br>' +
-                    '<small class="autocomplete-result__description muted" aria-label="' + title + '">' + title + '</small>' +
+                    '<small class="autocomplete-result__description muted">' + title + '</small>' +
                     '</a>\n</li>'
                 );
             }

--- a/pages/libraries.html
+++ b/pages/libraries.html
@@ -7,23 +7,23 @@ permalink: /libraries/
 <div aria-label="Languages" id="tabs">
   <ul role="tablist" class="nav nav-tabs" id="tablinks">
     <li role="presentation" class="active">
-      <a class="tab-link" href="#net1" aria-label=".net" role="tab" data-toggle="tab" aria-controls="net1">.NET</a>
+      <a class="tab-link" id="tab-net1" href="#net1" aria-label=".net" role="tab" data-toggle="tab" aria-controls="net1">.NET</a>
     </li>
     <li role="presentation">
-      <a class="tab-link" href="#java" aria-label="Java" role="tab" data-toggle="tab" aria-controls="java" tabindex="-1">Java</a>
+      <a class="tab-link" id="tab-java" href="#java" aria-label="Java" role="tab" data-toggle="tab" aria-controls="java" tabindex="-1">Java</a>
     </li>
     <li role="presentation">
-      <a class="tab-link" href="#javascript" aria-label="JavaScript" role="tab" data-toggle="tab" aria-controls="javascript" tabindex="-1">JavaScript</a>
+      <a class="tab-link" id="tab-javascript" href="#javascript" aria-label="JavaScript" role="tab" data-toggle="tab" aria-controls="javascript" tabindex="-1">JavaScript</a>
     </li>
     <li role="presentation">
-      <a class="tab-link" href="#cpp" aria-label="C++" role="tab" data-toggle="tab" aria-controls="cpp" tabindex="-1">C++</a>
+      <a class="tab-link" id="tab-cpp" href="#cpp" aria-label="C++" role="tab" data-toggle="tab" aria-controls="cpp" tabindex="-1">C++</a>
     </li>
     <li role="presentation">
-      <a class="tab-link" href="#other" aria-label="Other Platforms" role="tab" data-toggle="tab" aria-controls="other" tabindex="-1">Other Platforms</a>
+      <a class="tab-link" id="tab-other" href="#other" aria-label="Other Platforms" role="tab" data-toggle="tab" aria-controls="other" tabindex="-1">Other Platforms</a>
     </li>
   </ul>
   <div class="tab-content">
-    <div class="tab-pane active" id="net1" role="tabpanel" tabindex="0">
+    <div class="tab-pane active" id="net1" role="tabpanel" aria-labelledby="tab-net1" tabindex="0">
       <table class="table table-striped table-condensed table-hover reflows" aria-label=".NET Libraries">
         <thead>
         <tr>
@@ -62,7 +62,7 @@ permalink: /libraries/
     {% for library in libraries %}
     {% if library.name != "net" %}
 
-    <div class="tab-pane" id="{{library.name}}" role="tabpanel" hidden>
+    <div class="tab-pane" id="{{library.name}}" role="tabpanel" aria-labelledby="tab-{{library.name}}" hidden>
       <table class="table table-striped table-condensed table-hover reflows" aria-label="{{library.name}} Libraries">
         <thead>
         <tr>

--- a/pages/reference-service.html
+++ b/pages/reference-service.html
@@ -7,18 +7,18 @@ permalink: /odata-services/
 <div id="services-tab">
 <ul class="nav nav-tabs" role="tablist" aria-label="Versions"> 
   <li class="active" role="presentation">
-    <a class="tab-link" href="#odata-v4" role="tab" aria-controls="odata-v4" data-toggle="tab">OData v4</a>
+    <a class="tab-link" id="tab-odata-v4" href="#odata-v4" role="tab" aria-controls="odata-v4" data-toggle="tab">OData v4</a>
   </li>
   <li role="presentation">
-    <a class="tab-link"  href="#v3" role="tab" data-toggle="tab" aria-controls="v3" tabindex="-1">OData v3</a>
+    <a class="tab-link" id="tab-v3" href="#v3" role="tab" data-toggle="tab" aria-controls="v3" tabindex="-1">OData v3</a>
   </li>
   <li role="presentation">
-    <a class="tab-link" href="#v2" role="tab" data-toggle="tab" aria-controls="v2" tabindex="-1">OData v2</a>
+    <a class="tab-link" id="tab-v2" href="#v2" role="tab" data-toggle="tab" aria-controls="v2" tabindex="-1">OData v2</a>
   </li>
 </ul>
 
 <div class="tab-content">
-  <div id="odata-v4" tabindex="0" class="tab-pane active" role="tabpanel">
+  <div id="odata-v4" tabindex="0" class="tab-pane active" role="tabpanel" aria-labelledby="tab-odata-v4">
     <table class="table table-striped table-condensed table-hover reflows" aria-label="OData v4 Reference Services">
         <thead>
             <tr>
@@ -67,7 +67,7 @@ permalink: /odata-services/
         </tbody>
     </table>
   </div>
-  <div class="tab-pane" id="v3" role="tabpanel" hidden>
+  <div class="tab-pane" id="v3" role="tabpanel" aria-labelledby="tab-v3" hidden>
     <table class="table table-striped table-condensed table-hover" aria-label="OData v3 Reference Services">
         <thead>
           <tr>
@@ -91,7 +91,7 @@ permalink: /odata-services/
       </tbody>
     </table>
   </div>
-  <div class="tab-pane" id="v2" role="tabpanel" hidden>
+  <div class="tab-pane" id="v2" role="tabpanel" aria-labelledby="tab-v2" hidden>
     <table class="table table-striped table-condensed table-hover" aria-label="OData v2 Reference Services">
         <thead>
             <tr>


### PR DESCRIPTION
Fix screen reader and ARIA accessibility issues across multiple pages:

- [OData - Getting Started - TripPin Reference Service]: Add aria-labelledby to tab panels so screen readers announce panel names (e.g., 'OData v4') when switching tabs
- [OData - Libraries]: Same tab panel labelling fix applied to all language tab panels (.NET, Java, JavaScript, C++, Other)
- [OData - Home]: Remove redundant aria-label from dropdown menus (Developers, Tools) that caused link names to be announced twice
- [OData - Developers - Advanced Tutorial]: Add aria-current='page' to navigation links via Liquid conditionals so screen readers announce which page is currently active
- [OData - Home]: Fix search suggestion rendering to prevent 'undefined' being announced — add fallback title, strip HTML tags from aria-label, remove redundant aria-label from description