### PR TITLE
fix(a11y): prevent carousel caption text truncation at high zoom

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,16 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* When the "Recent Posts" columns stack (below Bootstrap's md breakpoint, i.e.
+   <=991px, which includes 400% zoom on a 1280px viewport per WCAG 1.4.10
+   Reflow), let the carousel caption flow below the image instead of being
+   clipped by the fixed-height absolute overlay, so its text is not truncated. */
+@media (max-width: 991px) {
+  .carousel-caption {
+    position: static;
+    margin: 0;
+    max-width: none;
+    max-height: none;
+  }
+}


### PR DESCRIPTION
## Problem
At 400% zoom the "Recent Posts" carousel slide grows taller than its background image and is clipped by `.carousel-inner { overflow: hidden }`, truncating the caption text (WCAG 1.4.10 Reflow).

## Where the issue is
The homepage carousel "Recent Posts" slide at 400% page zoom.

## Solution
Below Bootstrap's md breakpoint (<=991px), let the caption flow in normal document flow (`position: static`, no negative margins, no max-height) so the carousel container grows to fit it. The >=992px desktop overlay is unchanged.

## Where in code
- `public/css/site.css` - new `@media (max-width: 991px)` block overriding `.carousel-caption`.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._


## Before at 400% zoom
<img width="1263" height="971" alt="image" src="https://github.com/user-attachments/assets/e6aff140-bfae-41fa-ab4f-a6e2ffe7e1da" />

## After at 400% zoom
<img width="1161" height="944" alt="image" src="https://github.com/user-attachments/assets/9cc1c29b-2112-40f0-b84d-aee675d87bcd" />
