### PR TITLE
fix(a11y): visible focus indicator on navbar hamburger toggle

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,24 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* Accessibility fix — MAS 1.4.1 (non-text contrast of focus indicator).
+   Bootstrap 3 removes the focus ring via `.navbar-toggle:focus { outline: 0 }`, so the responsive
+   "Hamburger" toggle showed no visible keyboard focus boundary (measured ~1.389:1) at narrow
+   widths / high zoom. Add a solid 2px outline (shape-based, not color-alone) with an offset so it
+   sits just outside the button. White (#fff) over the orange navbar (#d24714) is ~4.5:1, which
+   exceeds the WCAG 3:1 non-text contrast threshold. Only the outline is added — Bootstrap's focus
+   background-color is left intact, and outline/outline-offset do not affect layout.
+   `:focus` and `:focus-visible` are kept as separate rules so the universally-supported `:focus`
+   fallback still applies on browsers that do not understand `:focus-visible` (a single selector
+   list would be dropped entirely if one selector is unrecognized). Both selectors share the
+   specificity (0,2,0) of Bootstrap's `.navbar-toggle:focus { outline: 0 }` and win the cascade
+   because site.css loads after bootstrap.min.css. */
+.navbar-toggle:focus {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+.navbar-toggle:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Problem
Bootstrap 3 removes the focus ring via `.navbar-toggle:focus { outline: 0 }`, so the responsive "Hamburger" toggle has no visible keyboard focus boundary (measured ~1.389:1), failing MAS 1.4.1 non-text contrast of the focus indicator.

## Where the issue is
The navbar "Hamburger" menu toggle on the Home page (and all pages) at 400% zoom / narrow viewports.

## Solution
Add a `2px solid #fff` focus outline in `site.css`; white over the orange navbar (`#d24714`) is ~4.51:1, exceeding the 3:1 threshold. `:focus` and `:focus-visible` are kept as separate rules for browser fallback. Navbar layout and collapse behavior are unchanged.

## Where in code
- `public/css/site.css` - new `.navbar-toggle:focus` and `.navbar-toggle:focus-visible` rules.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._