### PR TITLE
fix(a11y): wrap long URLs and identifiers in body text at high zoom

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,13 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* Reflow long, unbreakable strings (URLs, namespaces, identifiers) in body text
+   so they wrap instead of overflowing/truncating at high zoom (WCAG 1.4.10). */
+p,
+li,
+dd,
+dt {
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}


### PR DESCRIPTION
## Problem
Long unbreakable strings (for example the namespace URL and dotted identifiers) rendered as plain body text did not wrap and overflowed their container, getting clipped by `body { overflow-x: hidden }` at 400% zoom (WCAG 1.4.10 Reflow).

## Where the issue is
The long URL text under "5.1.3. OData Data Namespace" on Developers -> OData Version 3.0 Atom Format (and similar long strings in body copy).

## Solution
Add `overflow-wrap: break-word` to `p, li, dd, dt` so long words wrap to the next line and stay readable without horizontal scrolling. Code blocks (`pre` / `code` / `.highlight`) are intentionally left untouched.

## Where in code
- `public/css/site.css` - `overflow-wrap: break-word` on `p, li, dd, dt`.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._

## Before
<img width="1279" height="1023" alt="image" src="https://github.com/user-attachments/assets/839b94a9-a08e-43ca-a03f-1d946f27117b" />

## After
<img width="1252" height="1014" alt="image" src="https://github.com/user-attachments/assets/146a6fef-1a20-40bf-ae40-460e7a7e38d8" />
