### PR TITLE
fix(a11y): focus indicator + contrast for modal close button

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,30 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* ---------------------------------------------------------------------------
+   Accessibility: Bootstrap modal "Close (X)" button — non-text contrast + focus
+   Addresses MAS 1.4.11 (Non-text Contrast).
+   Bootstrap's default .close paints the black glyph at opacity:.2, which
+   composites to ~#ccc on the white (#fff) modal header (~1.6:1), and shows no
+   visible keyboard focus ring. Raising the opacity darkens the glyph and a
+   solid outline supplies the focus indicator (not color alone). Scoped to
+   .close so every Bootstrap close button is covered site-wide, matching the
+   .dropdown-toggle:focus outline pattern above. Additive only — no layout or
+   modal open/close behavior change.
+   --------------------------------------------------------------------------- */
+.close {
+  color: #000;        /* opacity .6 composites #000 -> ~#666 on #fff = 5.74:1 (>= 3:1) */
+  opacity: 0.6;
+}
+.close:hover {
+  color: #000;
+  opacity: 1;         /* full-strength glyph: #000 on #fff = 21:1 */
+}
+.close:focus,
+.close:focus-visible {
+  color: #000;
+  opacity: 1;
+  outline: 2px solid #424242;   /* focus ring: #424242 on #fff = ~10:1 (>= 3:1) */
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Problem
The Bootstrap modal "Close (X)" button renders its glyph at `opacity: .2` (~1.6:1 against the white modal header) and shows no visible keyboard focus indicator (measured 1.605:1), failing WCAG / MAS 1.4.11 Non-text Contrast.

## Where the issue is
The "Close (X)" button of the response/example popup modals on the Developers pages. The fix applies to every Bootstrap `.close` button site-wide.

## Solution
Add a `site.css` override that raises the glyph contrast to >=3:1 and adds a `2px solid #424242` focus outline (~10:1). Additive only - no layout or behavior change.

## Where in code
- `public/css/site.css` - new `.close`, `.close:hover`, and `.close:focus` / `.close:focus-visible` rules.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._