### PR TITLE
fix(a11y): add persistent instructions for search field

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -91,6 +91,7 @@
                         <input id="main-search-input"
                                type="text"
                                aria-label="Search"
+                               aria-describedby="main-search-instructions"
                                class="form-control st-default-search-input"
                                placeholder="Search"
                                role="combobox"
@@ -104,6 +105,7 @@
                                 aria-expanded="false"
                                 aria-controls="search-results">
                         </button>
+                        <span id="main-search-instructions" class="sr-only">Search the OData site. Suggestions appear below as you type; use the up and down arrow keys to review suggestions and Enter to open the selected result.</span>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Problem
The Search combobox relied on a placeholder that disappears once the user types, leaving no persistent label or instructions describing its purpose, failing WCAG 3.3.2 (Labels or Instructions).

## Where the issue is
The "Search Suggestion" edit field in the navbar on the Home page (applies site-wide via the shared navbar include).

## Solution
Add programmatically-associated, persistent instructions via `aria-describedby` pointing to an `sr-only` element that describes the field and how to operate the suggestions (arrow keys / Enter). The existing `aria-label="Search"` is preserved.

## Where in code
- `_includes/navbar.html` - `aria-describedby="main-search-instructions"` on the input plus a new `<span id="main-search-instructions" class="sr-only">...</span>`.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._