### PR TITLE
fix(a11y): announce current state on tutorial page-navigation links

### DIFF
--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -706,7 +706,7 @@ permalink: /getting-started/advanced-tutorial/
       <nav class="tutorial-sidebar" aria-label="Page Contents">
          <ul class="nav tutorial-sidenav" data-spy="affix">
             <li class="sidebar-nav-item active">
-               <a href="#singleton">Singleton</a>
+               <a href="#singleton" aria-current="true">Singleton</a>
                <ul class="nav">
                   <li><a href="#querySingleton">Requesting Singleton</a></li>
                   <li><a href="#querySingletonProperty">Requesting Property of Singleton Property</a></li>
@@ -775,13 +775,19 @@ permalink: /getting-started/advanced-tutorial/
       $(document).ready(function () {
          $('.tutorial-sidebar').affix('checkPosition');
 
-         // Add click event listener to the sidebar links
-         $('.sidenav-link').on('click', function (e) {
-            // Remove 'active' class from all sidebar nav items
-            $(".sidebar-nav-item").removeClass('active');
-            // Add 'active' class to the parent of the clicked link's parent
-            $(this).parent().parent().addClass('active');
+         // Keep aria-current in sync with the Scrollspy-managed active section so
+         // screen readers always announce the section the user is currently on.
+         function syncAriaCurrent() {
+            $('.tutorial-sidenav > li > a').removeAttr('aria-current');
+            $('.tutorial-sidenav > li.active > a').attr('aria-current', 'true');
+         }
+         $('body').on('activate.bs.scrollspy', syncAriaCurrent);
+         $('.tutorial-sidenav > li > a').on('click', function () {
+            $('.tutorial-sidenav > li').removeClass('active');
+            $(this).parent().addClass('active');
+            syncAriaCurrent();
          });
+         syncAriaCurrent();
       });
    
 </script>

--- a/pages/getting-started/advanced-tutorial.html
+++ b/pages/getting-started/advanced-tutorial.html
@@ -778,6 +778,7 @@ permalink: /getting-started/advanced-tutorial/
          // Keep aria-current in sync with the Scrollspy-managed active section so
          // screen readers always announce the section the user is currently on.
          function syncAriaCurrent() {
+            $('.tutorial-sidenav > a').removeAttr('aria-current');
             $('.tutorial-sidenav > li > a').removeAttr('aria-current');
             $('.tutorial-sidenav > li.active > a').attr('aria-current', 'true');
          }

--- a/pages/getting-started/basic-tutorial.html
+++ b/pages/getting-started/basic-tutorial.html
@@ -985,7 +985,7 @@ HTTP/1.1 204 No Content
     <nav class="tutorial-sidebar affix" aria-label="Page Contents" id="affix-navbar">
         <ul class="nav tutorial-sidenav" data-spy="affix">
             <li class="sidebar-nav-item active">
-                <p><a href="#requestData" class="sidenav-link">Requesting Data</a></p>
+                <p><a href="#requestData" class="sidenav-link" aria-current="true">Requesting Data</a></p>
                 <ul class="nav">
                     <li><a href="#entitySet">Requesting Entity Collections</a></li>
                     <li><a href="#entityByID">Requesting an Individual Entity by ID</a></li>
@@ -1048,13 +1048,19 @@ HTTP/1.1 204 No Content
         $(document).ready(function () {
             $('.tutorial-sidebar').affix('checkPosition');
 
-            // Add click event listener to the sidebar links
+            // Keep aria-current in sync with the Scrollspy-managed active section so
+            // screen readers always announce the section the user is currently on.
+            function syncAriaCurrent() {
+                $('.sidenav-link').removeAttr('aria-current');
+                $('.sidebar-nav-item.active .sidenav-link').attr('aria-current', 'true');
+            }
+            $('body').on('activate.bs.scrollspy', syncAriaCurrent);
             $('.sidenav-link').on('click', function (e) {
-                // Remove 'active' class from all sidebar nav items
                 $(".sidebar-nav-item").removeClass('active');
-                // Add 'active' class to the parent of the clicked link's parent
                 $(this).parent().parent().addClass('active');
+                syncAriaCurrent();
             });
+            syncAriaCurrent();
         });
     
 </script>


### PR DESCRIPTION
## Problem
The "Page Contents" navigation marked the active section's `<li>` with the `.active` class (Bootstrap Scrollspy) but exposed no programmatic current state, so screen readers announced only the link text and not "current" (MAS 4.1.2).

## Where the issue is
The right-hand page-navigation links on Developers -> Advanced Tutorial (and Basic Tutorial).

## Solution
Add `aria-current` to the active page-navigation link and keep it in sync with the Scrollspy-managed `.active` class as the single source of truth: re-derived on scroll (`activate.bs.scrollspy`), on click, and on initial load.

## Where in code
- `pages/getting-started/advanced-tutorial.html` and `pages/getting-started/basic-tutorial.html` - `aria-current="true"` on the active link plus a `syncAriaCurrent()` handler.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._