### PR TITLE
fix(a11y): stack tutorial page-contents sidebar at high zoom so links are not truncated

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,33 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* The basic/advanced tutorial pages use a custom percentage grid whose columns
+   stay floated at fixed widths at all sizes, so at high zoom / narrow viewports
+   the right-hand "Page Contents" sidebar (.col-1-4) collapses to a narrow strip
+   and its links (e.g. those under "Singleton") are truncated. Below 768px, stack
+   the custom-grid columns full-width and keep the sidebar in normal flow
+   (un-affixed, un-floated) so every link reflows and stays visible (WCAG 1.4.10).
+   Only the custom .col-* classes are targeted (used solely by these tutorial
+   pages); Bootstrap's grid is untouched. float:none !important is required to
+   override the inline float:right on the Advanced Tutorial sidebar. */
+@media (max-width: 767px) {
+  .col-2-3,
+  .col-1-3,
+  .col-1-2,
+  .col-1-4,
+  .col-1-8,
+  .col-1-12,
+  .col-3-4,
+  .col-3-8 {
+    width: 100%;
+    float: none !important;
+  }
+  .tutorial-sidebar.affix,
+  .tutorial-sidebar.affix-bottom,
+  .tutorial-sidebar .affix {
+    position: static !important;
+    top: auto !important;
+    float: none;
+  }
+}


### PR DESCRIPTION
## Problem
The tutorial pages use a custom percentage grid whose columns stay floated at fixed widths with no responsive breakpoints, so at high zoom / narrow viewports the right-hand "Page Contents" sidebar (`.col-1-4`) collapses to a narrow strip and its links are clipped by `body { overflow-x: hidden }`.

## Where the issue is
The links under "Singleton" in the "Page Contents" sidebar on Developers -> Advanced Tutorial (and Basic Tutorial), at 400% zoom.

## Solution
Below 768px (covering 320px at 400% zoom and 640px at 200%), stack the custom-grid columns full-width and keep the sidebar in normal flow (`position: static`, un-floated) so every link reflows and stays visible. Only the custom `.col-*` classes (used solely by the two tutorial pages) are targeted, so Bootstrap's grid is unaffected.

## Where in code
- `public/css/site.css` - new `@media (max-width: 767px)` block for the custom `.col-*` classes and sidebar.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._

## Before
<img width="1261" height="939" alt="image" src="https://github.com/user-attachments/assets/1401e62d-4a75-4d06-8bca-40aab163ea70" />

## After
Place at the bottom:
<img width="1267" height="864" alt="image" src="https://github.com/user-attachments/assets/bfb306bc-41a1-4e3c-962f-eb7d0704507a" />
