### PR TITLE
fix(a11y): scroll active search suggestion into view

### DIFF
--- a/public/combobox-autocomplete.js
+++ b/public/combobox-autocomplete.js
@@ -208,7 +208,13 @@ ComboboxAutocomplete.prototype.setCurrentOptionStyle = function (option) {
             // internal scroll container, so the browser will not auto-scroll to the active
             // option. Scroll it into view so it is never obscured (WCAG 2.4.11).
             if (typeof opt.scrollIntoView === 'function') {
-                opt.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+                try {
+                    opt.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+                }
+                catch (e) {
+                    // Older browsers may only support the boolean signature.
+                    opt.scrollIntoView(false);
+                }
             }
         }
         else {

--- a/public/combobox-autocomplete.js
+++ b/public/combobox-autocomplete.js
@@ -204,6 +204,12 @@ ComboboxAutocomplete.prototype.setCurrentOptionStyle = function (option) {
             else if (this.listboxNode.scrollTop > (opt.offsetTop + 2)) {
                 this.listboxNode.scrollTop = opt.offsetTop;
             }
+            // Focus stays on the input (aria-activedescendant), and the listbox is not an
+            // internal scroll container, so the browser will not auto-scroll to the active
+            // option. Scroll it into view so it is never obscured (WCAG 2.4.11).
+            if (typeof opt.scrollIntoView === 'function') {
+                opt.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+            }
         }
         else {
             opt.removeAttribute('aria-selected');


### PR DESCRIPTION
## Problem
Because the combobox uses `aria-activedescendant` (DOM focus stays on the input) and the suggestions listbox is not an internal scroll container, the browser never auto-scrolled to the active option, so arrow-key users could lose sight of the focused suggestion below the fold (WCAG 2.4.11 Focus Not Obscured).

## Where the issue is
The search typeahead suggestions inside the search box on the Home page.

## Solution
`setCurrentOptionStyle` now calls `scrollIntoView({ block: 'nearest' })` on the active option (guarded by a feature check), complementing the existing listbox `scrollTop` logic without double-scroll jank.

## Where in code
- `public/combobox-autocomplete.js` - `setCurrentOptionStyle()` adds the `scrollIntoView` call.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._