### PR TITLE
fix(a11y): make over-wide data tables horizontally scrollable and keyboard-operable at high zoom

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -139,10 +139,9 @@
         }
     }
 
-    // Wrap over-wide data tables in a focusable, labeled scroll region so they are
-    // not clipped at high zoom, while preserving the table's native semantics.
-    // Data tables are exempt from WCAG 1.4.10 reflow; this keeps them keyboard-
-    // and AT-accessible (also addresses 2.1.1).
+    // Wrap data tables in a horizontal-scroll wrapper so they are not clipped at high zoom,
+    // while preserving the table's native semantics. The wrapper becomes a focusable,
+    // labeled scroll region only when the table actually overflows (WCAG 1.4.10 / 2.1.1).
     function setupScrollableTables() {
         $('.container table').not('.reflows').not('.other-protocols-table').each(function() {
             if ($(this).parent('.table-scroll').length === 0) {

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -138,6 +138,58 @@
             $("span.cell-content").contents().unwrap();
         }
     }
+
+    // Wrap over-wide data tables in a focusable, labeled scroll region so they are
+    // not clipped at high zoom, while preserving the table's native semantics.
+    // Data tables are exempt from WCAG 1.4.10 reflow; this keeps them keyboard-
+    // and AT-accessible (also addresses 2.1.1).
+    function setupScrollableTables() {
+        $('.container table').not('.reflows').not('.other-protocols-table').each(function() {
+            if ($(this).parent('.table-scroll').length === 0) {
+                $(this).wrap('<div class="table-scroll"></div>');
+            }
+        });
+        updateScrollableTables();
+    }
+
+    function updateScrollableTables() {
+        $('.table-scroll').each(function() {
+            var wrapper = this;
+            var table = wrapper.firstElementChild;
+            if (!table) {
+                return;
+            }
+            if (table.scrollWidth > wrapper.clientWidth + 1) {
+                if (!wrapper.hasAttribute('tabindex')) {
+                    var caption = table.querySelector('caption');
+                    var ariaLabel = (table.getAttribute('aria-label') || '').trim();
+                    var labelledbyId = table.getAttribute('aria-labelledby');
+                    var labelledbyEl = labelledbyId ? document.getElementById(labelledbyId) : null;
+                    var label =
+                        (caption && caption.textContent.trim()) ? caption.textContent.trim() :
+                        ariaLabel ? ariaLabel :
+                        (labelledbyEl && labelledbyEl.textContent.trim()) ? labelledbyEl.textContent.trim() :
+                        'Table';
+                    wrapper.setAttribute('role', 'region');
+                    wrapper.setAttribute('aria-label', label + ', scrollable');
+                    wrapper.setAttribute('tabindex', '0');
+                }
+            } else {
+                wrapper.removeAttribute('tabindex');
+                wrapper.removeAttribute('role');
+                wrapper.removeAttribute('aria-label');
+            }
+        });
+    }
+
+    $(document).ready(function() {
+        setupScrollableTables();
+    });
+    window.addEventListener("resize", updateScrollableTables);
+    window.addEventListener("load", updateScrollableTables);
+    // Tables inside inactive tab-panes measure 0 until shown; recompute on tab show.
+    $(document).on('shown.bs.tab shown.bs.pill', updateScrollableTables);
+
     $(".dropdown").on("show.bs.dropdown", function(event){
        $(this).children('a[role=menuitem]').attr('aria-expanded', true);
     });

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -495,3 +495,15 @@ td {
   font-weight: bold;
   color: green;
 }
+
+/* Focusable horizontal-scroll wrapper for over-wide data tables, so they are not
+   clipped at high zoom and remain keyboard-operable (WCAG 1.4.10 / 2.1.1). */
+.table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
+}
+.table-scroll:focus {
+  outline: 2px solid #424242;
+  outline-offset: 2px;
+}

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -496,8 +496,8 @@ td {
   color: green;
 }
 
-/* Focusable horizontal-scroll wrapper for over-wide data tables, so they are not
-   clipped at high zoom and remain keyboard-operable (WCAG 1.4.10 / 2.1.1). */
+/* Horizontal-scroll wrapper for wide data tables. JS makes it focusable/labeled only
+   when the table actually overflows, so it remains keyboard-operable at high zoom. */
 .table-scroll {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Problem
Wide documentation data tables were truncated at 400% zoom because `body { overflow-x: hidden }` clips anything wider than the viewport.

## Where the issue is
The table under the "Logical Operators" section on Developers -> OData Version 3.0 Core Protocol (and other over-wide data tables).

## Solution
Data tables are exempt from WCAG 1.4.10 reflow, so wrap each over-wide table (excluding `.reflows` and `.other-protocols-table`) in a `.table-scroll` div that scrolls horizontally. The wrapper becomes a focusable, labeled region (`role=region`, `aria-label`, `tabindex=0`) only when the table actually overflows - keyboard-operable (2.1.1) without needless tab stops, with native table semantics preserved. Overflow is recomputed on load, resize, and tab/pill show.

## Where in code
- `_includes/scripts.html` - `setupScrollableTables()` / `updateScrollableTables()`.
- `public/css/site.css` - `.table-scroll` styles.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._

## Before
<img width="1252" height="880" alt="image" src="https://github.com/user-attachments/assets/6952ccb3-1bde-4994-92f5-0aac8bd053a1" />

## After
<img width="1145" height="895" alt="image" src="https://github.com/user-attachments/assets/d2abc71c-69a7-40b7-8fdd-98770046f57c" />
