### PR TITLE
fix(a11y): announce tab panel names via aria-labelledby

### DIFF
--- a/public/tabs.js
+++ b/public/tabs.js
@@ -63,7 +63,7 @@
           };
 
           // Do not overwrite a name already provided in the markup
-          if (!panel.hasAttribute('aria-labelledby')) {
+          if (!panel.hasAttribute('aria-labelledby') && !panel.hasAttribute('aria-label')) {
             panel.setAttribute('aria-labelledby', tab.id);
           };
         };

--- a/public/tabs.js
+++ b/public/tabs.js
@@ -31,10 +31,42 @@
       let delay = determineDelay();
 
       generateArrays();
+      labelPanels();
 
       function generateArrays () {
         tabs.push.apply(tabs, tablist.querySelectorAll('[role="tab"]'));
         panels.push.apply(panels, tablist.parentElement.querySelectorAll('[role="tabpanel"]'));
+      };
+
+      // Give each tab panel an accessible name derived from its controlling tab,
+      // so screen readers announce the panel's name (WCAG 4.1.2 Name/Role/Value)
+      function labelPanels () {
+        for (let i = 0; i < tabs.length; i++) {
+          var tab = tabs[i];
+          var controls = tab.getAttribute('aria-controls');
+
+          // Skip tabs that do not reference a panel
+          if (!controls) {
+            continue;
+          };
+
+          var panel = document.getElementById(controls);
+
+          // Skip when the referenced panel does not exist
+          if (!panel) {
+            continue;
+          };
+
+          // Ensure the controlling tab has a stable id to point the panel at
+          if (!tab.id) {
+            tab.id = controls + '-tab';
+          };
+
+          // Do not overwrite a name already provided in the markup
+          if (!panel.hasAttribute('aria-labelledby')) {
+            panel.setAttribute('aria-labelledby', tab.id);
+          };
+        };
       };
 
       // Bind listeners


### PR DESCRIPTION
## Problem
Tab panels (`role="tabpanel"`) had no accessible name, so screen readers announced only "tab panel" when focus moved into a panel, failing WCAG 4.1.2 (Name, Role, Value).

## Where the issue is
The "OData v4" tab panel on the Getting Started -> TripPin Reference Service page (also the Libraries and "Understand OData in 6 steps" pages).

## Solution
`tabs.js` derives each panel's name from its controlling tab, wiring the panel's `aria-labelledby` to the tab's `id` (assigning a stable id when the tab lacks one) without overwriting any `aria-labelledby` / `id` already present in the markup.

## Where in code
- `public/tabs.js` - new `labelPanels()` routine.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._