### PR TITLE
fix(a11y): remove duplicate screen-reader announcement under Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ layout: default
       <h2 class="text-left theme-font">Tools</h2>
       <table>
         <tr>
-          <td width="40%"><img src="{{'/assets/vs_code_for_odata.gif' | prepend: site.baseurl | prepend: site.url}}" alt="" width = 90%></td>
+          <td width="40%"><img src="{{'/assets/vs_code_for_odata.gif' | prepend: site.baseurl | prepend: site.url}}" alt="" width="90%"></td>
           <td>
             <h3><a href="https://marketplace.visualstudio.com/items?itemName=stansw.vscode-odata ">Visual Studio Code for OData</a></h3>
             <p>OData for Visual Studio Code is a Visual Studio Code extension that adds rich support for the OData query language</p>

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@ layout: default
       <h2 class="text-left theme-font">Tools</h2>
       <table>
         <tr>
-          <td width="40%"><img src="{{'/assets/vs_code_for_odata.gif' | prepend: site.baseurl | prepend: site.url}}" alt="Visual Studio Code for OData" width = 90%></td>
+          <td width="40%"><img src="{{'/assets/vs_code_for_odata.gif' | prepend: site.baseurl | prepend: site.url}}" alt="" width = 90%></td>
           <td>
             <h3><a href="https://marketplace.visualstudio.com/items?itemName=stansw.vscode-odata ">Visual Studio Code for OData</a></h3>
             <p>OData for Visual Studio Code is a Visual Studio Code extension that adds rich support for the OData query language</p>
@@ -138,7 +138,7 @@ layout: default
         </tr>
         -->
         <tr>
-          <td width="40%"><img src="{{'/assets/xodata_tool.jpg' | prepend: site.baseurl | prepend: site.url}}" alt="xodata" width="90%"></td>
+          <td width="40%"><img src="{{'/assets/xodata_tool.jpg' | prepend: site.baseurl | prepend: site.url}}" alt="" width="90%"></td>
           <td>
             <h3><a href="https://pragmatiqa.com/xodata/">XOData</a></h3>
             <p>XOData is a generic online OData API/Service visualizer and explorer. It assists in rapid prototyping, verification, testing, and documentation of OData APIs. With XOData Chrome App it's also possible to explore OData Services deployed locally or on private networks.</p>


### PR DESCRIPTION
## Problem
Under the "Tools" heading, each tool screenshot's `alt` text duplicated the adjacent tool link, so screen readers announced the link name twice (MAS 4.1.2).

## Where the issue is
The "Tools" section on the Home page (the Visual Studio Code for OData and XOData entries).

## Solution
Mark the two screenshots decorative (`alt=""`) since the adjacent link already provides the accessible name. Visual rendering is unchanged.

## Where in code
- `index.html` - "Tools" table: `alt` emptied on the two tool `<img>` tags.

---
_Validated against WCAG 2.1 AA (keyboard, screen reader, and 400% zoom where applicable)._